### PR TITLE
Adjust wrong global imports

### DIFF
--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -3,22 +3,13 @@
  * For licensing, see LICENSE.md.
  */
 
-import type * as CKEditor from 'ckeditor5';
 import type { CKCdnResourcesPack } from '../loadCKCdnResourcesPack';
 
 import { createCKCdnUrl, type CKCdnVersion } from './createCKCdnUrl';
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { injectScriptsInParallel } from '../../utils/injectScript';
 
-/**
- * Type of the exported global variables of the base CKEditor bundle.
- */
-declare global {
-	interface Window {
-		CKEDITOR_VERSION?: string;
-		CKEDITOR?: typeof CKEditor;
-	}
-}
+import './globals.d';
 
 /**
  * Creates a pack of resources for the base CKEditor bundle.

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -6,11 +6,11 @@
 import type { CKCdnResourcesPack } from '../loadCKCdnResourcesPack';
 import type { CKCdnBaseBundlePackConfig } from './createCKCdnBaseBundlePack';
 
-import './globals.d';
-
 import { createCKCdnUrl } from './createCKCdnUrl';
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { injectScriptsInParallel } from '../../utils/injectScript';
+
+import './globals.d';
 
 /**
  * Creates a pack of resources for the CKEditor Premium Features.

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -3,23 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import type * as CKEditorPremiumFeatures from 'ckeditor5-premium-features';
-
 import type { CKCdnResourcesPack } from '../loadCKCdnResourcesPack';
 import type { CKCdnBaseBundlePackConfig } from './createCKCdnBaseBundlePack';
+
+import './globals.d';
 
 import { createCKCdnUrl } from './createCKCdnUrl';
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { injectScriptsInParallel } from '../../utils/injectScript';
-
-/**
- * Type of the exported global variables of the CKEditor Premium Features.
- */
-declare global {
-	interface Window {
-		CKEDITOR_PREMIUM_FEATURES?: typeof CKEditorPremiumFeatures;
-	}
-}
 
 /**
  * Creates a pack of resources for the CKEditor Premium Features.

--- a/src/cdn/ck/globals.d.ts
+++ b/src/cdn/ck/globals.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type * as CKEditorPremiumFeatures from 'ckeditor5-premium-features';
+import type * as CKEditor from 'ckeditor5';
+
+/**
+ * Exported global variables of the CKEditor and CKEditor Premium Features.
+ */
+export declare global {
+	interface Window {
+		CKEDITOR_VERSION?: string;
+		CKEDITOR?: typeof CKEditor;
+		CKEDITOR_PREMIUM_FEATURES?: typeof CKEditorPremiumFeatures;
+	}
+}

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -8,14 +8,7 @@ import type { CKCdnResourcesPack } from '../loadCKCdnResourcesPack';
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { createCKBoxCdnUrl, type CKBoxCdnVersion } from './createCKBoxCdnUrl';
 
-/**
- * Type of the exported global variables of the base CKBox bundle.
- */
-declare global {
-	interface Window {
-		CKBox?: unknown;
-	}
-}
+import './globals.d';
 
 /**
  * Creates a pack of resources for the base CKBox bundle.

--- a/src/cdn/ckbox/globals.d.ts
+++ b/src/cdn/ckbox/globals.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Exported global variables of the CKBox.
+ */
+export declare global {
+	interface Window {
+		CKBox?: any;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@
  */
 
 import './globals.d';
+import './cdn/ck/globals.d';
+import './cdn/ckbox/globals.d';
 
 export type { Awaitable } from './types/Awaitable';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add missing `declare global` CKEditor variables to final `index.d.ts` bundle. 

---

### Additional information

It was causing missing type information in hooks / composable results. 
