### PR TITLE
Release - add missing CKEditor window variables to final `index.d.ts` bundle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## [0.1.1](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.1.0...v0.1.1) (2024-08-20)
+
+Internal changes only (updated dependencies, documentation, etc.).
+
+
 ## [0.1.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.0.1...v0.1.0) (2024-08-20)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ Changelog
 
 ## [0.1.1](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.1.0...v0.1.1) (2024-08-20)
 
-Fix: Add missing CKEditor window variables to final `index.d.ts` bundle.
+### Bug fixes
+
+* Add missing CKEditor window variables to the final `index.d.ts` bundle. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/09e84c8270633c38c7857754219776659a4cfee2))
+
 
 ## [0.1.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.0.1...v0.1.0) (2024-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@ Changelog
 
 ## [0.1.1](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.1.0...v0.1.1) (2024-08-20)
 
-Internal changes only (updated dependencies, documentation, etc.).
-
+Fix: Add missing CKEditor window variables to final `index.d.ts` bundle.
 
 ## [0.1.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.0.1...v0.1.0) (2024-08-20)
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Changelog for v0.1.1.
