### PR TITLE
Fix `export declare` compiler fails on older TS versions

### DIFF
--- a/src/cdn/ck/globals.d.ts
+++ b/src/cdn/ck/globals.d.ts
@@ -9,10 +9,14 @@ import type * as CKEditor from 'ckeditor5';
 /**
  * Exported global variables of the CKEditor and CKEditor Premium Features.
  */
-export declare global {
+declare global {
 	interface Window {
 		CKEDITOR_VERSION?: string;
 		CKEDITOR?: typeof CKEditor;
 		CKEDITOR_PREMIUM_FEATURES?: typeof CKEditorPremiumFeatures;
 	}
 }
+
+// Expose CKBox to the global scope, avoid using `export declare` because it's not supported by the older TypeScript compilers.
+// Although it's supported by the TypeScript language service.
+export {};

--- a/src/cdn/ck/globals.d.ts
+++ b/src/cdn/ck/globals.d.ts
@@ -17,6 +17,6 @@ declare global {
 	}
 }
 
-// Expose CKBox to the global scope, avoid using `export declare` because it's not supported by the older TypeScript compilers.
+// Expose CKEditor to the global scope, avoid using `export declare` because it's not supported by the older TypeScript compilers.
 // Although it's supported by the TypeScript language service.
 export {};

--- a/src/cdn/ckbox/globals.d.ts
+++ b/src/cdn/ckbox/globals.d.ts
@@ -6,8 +6,12 @@
 /**
  * Exported global variables of the CKBox.
  */
-export declare global {
+declare global {
 	interface Window {
 		CKBox?: any;
 	}
 }
+
+// Expose CKBox to the global scope, avoid using `export declare` because it's not supported by the older TypeScript compilers.
+// Although it's supported by the TypeScript language service.
+export {};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: No longer raise `export modifier cannot be applied to ambient modules` error on older TS versions.

---

### Additional information

While newer versions of TS (`5.5.4`) don't complain about `export declare` (which is crucial for some augmentations in local functions), the older TS versions (`5.1.0`) complain about this:

![obraz](https://github.com/user-attachments/assets/03476da2-4510-4909-8a23-7e36124164df)

`skipLibCheck` must be set to `false` in importing project. 
