### PR TITLE
Remove Math.random from uid

### DIFF
--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -21,20 +21,8 @@ const HEX_NUMBERS = new Array( 256 ).fill( '' )
  * @returns An unique id string.
  */
 export function uid(): string {
-	// Let's create some positive random 32bit integers first.
-	//
-	// 1. Math.random() is a float between 0 and 1.
-	// 2. 0x100000000 is 2^32 = 4294967296.
-	// 3. >>> 0 enforces integer (in JS all numbers are floating point).
-	//
-	// For instance:
-	//		Math.random() * 0x100000000 = 3366450031.853859
-	// but
-	//		Math.random() * 0x100000000 >>> 0 = 3366450031.
-	const r1 = Math.random() * 0x100000000 >>> 0;
-	const r2 = Math.random() * 0x100000000 >>> 0;
-	const r3 = Math.random() * 0x100000000 >>> 0;
-	const r4 = Math.random() * 0x100000000 >>> 0;
+	// Generate 4 random 32-bit numbers.
+	const [ r1, r2, r3, r4 ] = crypto.getRandomValues( new Uint32Array( 4 ) );
 
 	// Make sure that id does not start with number.
 	return 'e' +

--- a/tests/utils/uid.test.ts
+++ b/tests/utils/uid.test.ts
@@ -3,10 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import { it, expect, describe } from 'vitest';
+import { it, expect, describe, vi, afterEach } from 'vitest';
 import { uid } from '@/utils/uid';
 
 describe( 'uid', () => {
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
 	it( 'uid should return a string starting with "e"', () => {
 		const id = uid();
 		expect( id.startsWith( 'e' ) ).toBe( true );
@@ -27,5 +31,11 @@ describe( 'uid', () => {
 		const id = uid();
 		const hexRegex = /^[a-fA-F0-9]+$/;
 		expect( hexRegex.test( id.substring( 1 ) ) ).toBe( true );
+	} );
+
+	it( 'uid should not use Math.random', () => {
+		const randomSpy = vi.spyOn( Math, 'random' );
+		uid();
+		expect( randomSpy ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Remove `Math.random()` from `uid` implementation. See https://github.com/cksource/ckeditor5-internal/issues/3742.

---

### Additional information

Follow-up of: https://github.com/ckeditor/ckeditor5/pull/16945
