### PR TITLE
Simplify end user API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,9 @@ jobs:
           name: Run build
           command: yarn build
       - run:
+          name: Check types of tests
+          command: yarn test:check:types
+      - run:
           name: Run unit tests
           command: yarn test
       - run:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint --quiet \"**/*.{ts,tsx}\"",
     "test": "vitest run --coverage",
     "test:watch": "vitest --ui --watch",
+    "test:check:types": "tsc --noEmit -p ./tsconfig.test.json",
     "changelog": "node ./scripts/changelog.js",
     "release:prepare-packages": "node ./scripts/preparepackages.js",
     "release:publish-packages": "node ./scripts/publishpackages.js"

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesPack } from '../loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../loadCKCdnResourcesPack';
 
 import { createCKCdnUrl, type CKCdnVersion } from './createCKCdnUrl';
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
@@ -32,7 +32,7 @@ export function createCKCdnBaseBundlePack(
 		version,
 		languages
 	}: CKCdnBaseBundlePackConfig
-): CKCdnResourcesPack<Window['CKEDITOR']> {
+): CKCdnResourcesAdvancedPack<Window['CKEDITOR']> {
 	const urls = {
 		scripts: [
 			// Load the main script of the base features.

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -65,7 +65,7 @@ export function createCKCdnBaseBundlePack(
 		stylesheets: urls.stylesheets,
 
 		// Pick the exported global variables from the window object.
-		getExportedEntries: async () =>
+		confirmPluginReady: async () =>
 			waitForWindowEntry( [ 'CKEDITOR' ] )
 	};
 }

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesPack } from '../loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../loadCKCdnResourcesPack';
 import type { CKCdnBaseBundlePackConfig } from './createCKCdnBaseBundlePack';
 
 import { createCKCdnUrl } from './createCKCdnUrl';
@@ -33,7 +33,7 @@ export function createCKCdnPremiumBundlePack(
 		version,
 		languages
 	}: CKCdnPremiumBundlePackConfig
-): CKCdnResourcesPack<Window['CKEDITOR_PREMIUM_FEATURES']> {
+): CKCdnResourcesAdvancedPack<Window['CKEDITOR_PREMIUM_FEATURES']> {
 	const urls = {
 		scripts: [
 			// Load the main script of the premium features.

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -66,7 +66,7 @@ export function createCKCdnPremiumBundlePack(
 		stylesheets: urls.stylesheets,
 
 		// Pick the exported global variables from the window object.
-		getExportedEntries: async () =>
+		confirmPluginReady: async () =>
 			waitForWindowEntry( [ 'CKEDITOR_PREMIUM_FEATURES' ] )
 	};
 }

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesPack } from '../loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../loadCKCdnResourcesPack';
 
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { createCKBoxCdnUrl, type CKBoxCdnVersion } from './createCKBoxCdnUrl';
@@ -19,22 +19,30 @@ import './globals.d';
  * ```ts
  * const { CKBox } = await loadCKCdnResourcesPack(
  * 	createCKBoxCdnBundlePack( {
- * 		version: '2.5.1'
+ * 		version: '2.5.1',
+ * 		theme: 'lark'
  * 	} )
  * );
  * ```
  */
-export function createCKBoxBundlePack( { version }: CKBoxCdnBundlePackConfig ): CKCdnResourcesPack<Window['CKBox']> {
+export function createCKBoxBundlePack(
+	{
+		version,
+		theme = 'lark'
+	}: CKBoxCdnBundlePackConfig
+): CKCdnResourcesAdvancedPack<Window['CKBox']> {
 	return {
 		// Load the main script of the base features.
 		scripts: [
 			createCKBoxCdnUrl( 'ckbox', 'ckbox.js', version )
 		],
 
-		// Load the default theme.
-		stylesheets: [
-			createCKBoxCdnUrl( 'ckbox', 'styles/themes/lark.css', version )
-		],
+		// Load optional theme, if provided. It's not required but recommended because it improves the look and feel.
+		...theme && {
+			stylesheets: [
+				createCKBoxCdnUrl( 'ckbox', `styles/themes/${ theme }.css`, version )
+			]
+		},
 
 		// Pick the exported global variables from the window object.
 		getExportedEntries: async () =>
@@ -51,4 +59,9 @@ export type CKBoxCdnBundlePackConfig = {
 	 * The version of  the base CKEditor bundle.
 	 */
 	version: CKBoxCdnVersion;
+
+	/**
+	 * The theme of the CKBox bundle. Default is 'lark'.
+	 */
+	theme?: string | null;
 };

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -45,7 +45,7 @@ export function createCKBoxBundlePack(
 		},
 
 		// Pick the exported global variables from the window object.
-		getExportedEntries: async () =>
+		confirmPluginReady: async () =>
 			waitForWindowEntry( [ 'CKBox' ] )
 	};
 }

--- a/src/cdn/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/combineCKCdnBundlesPacks.ts
@@ -3,7 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesPack, InferCKCdnResourcesPackExportsType } from './loadCKCdnResourcesPack';
+import { filterBlankObjectValues } from '../utils/filterBlankObjectValues';
+import { mapObjectValues } from '../utils/mapObjectValues';
+import {
+	normalizeCKCdnResourcesPack,
+	type CKCdnResourcesPack,
+	type InferCKCdnResourcesPackExportsType,
+	type CKCdnResourcesAdvancedPack
+} from './loadCKCdnResourcesPack';
 
 /**
  * Combines multiple CKEditor CDN bundles packs into a single pack.
@@ -28,43 +35,56 @@ import type { CKCdnResourcesPack, InferCKCdnResourcesPackExportsType } from './l
  * ```
  */
 export function combineCKCdnBundlesPacks<P extends CKCdnBundlesPacks>( packs: P ): CKCdnCombinedBundlePack<P> {
-	const allPacks = Object
-		.values( packs )
-		.filter( pack => pack !== undefined );
+	const normalizedPacks = mapObjectValues(
+		filterBlankObjectValues( packs ),
+		normalizeCKCdnResourcesPack
+	);
+
+	// Merge all scripts, stylesheets and preload resources from all packs.
+	const mergedPacks = Object
+		.values( normalizedPacks )
+		.reduce(
+			( acc, pack ) => {
+				acc.scripts!.push( ...( pack.scripts ?? [] ) );
+				acc.stylesheets!.push( ...( pack.stylesheets ?? [] ) );
+				acc.preload!.push( ...( pack.preload ?? [] ) );
+
+				return acc;
+			},
+			{
+				preload: [],
+				scripts: [],
+				stylesheets: []
+			}
+		);
+
+	// Get exported entries from all packs.
+	const getExportedEntries = async () => {
+		// Use Object.create() to create an object without a prototype to avoid prototype pollution.
+		const exportedGlobalVariables: Record<string, unknown> = Object.create( null );
+
+		// It can be done sequentially because scripts *should* be loaded at this point and the whole execution should be quite fast.
+		for ( const [ name, pack ] of Object.entries( normalizedPacks ) ) {
+			exportedGlobalVariables[ name ] = await pack?.getExportedEntries?.();
+		}
+
+		return exportedGlobalVariables as any;
+	};
 
 	return {
-		// Combine all preloads from all packs into a single array.
-		preload: allPacks.flatMap( pack => pack.preload ?? [] ),
-
-		// Combine all scripts from all packs into a single array and preserve order.
-		scripts: allPacks.flatMap( pack => pack.scripts ?? [] ),
-
-		// Combine all stylesheets from all packs into a single array and preserve order.
-		stylesheets: allPacks.flatMap( pack => pack.stylesheets ?? [] ),
-
-		// Map all exports into one big object.
-		getExportedEntries: async () => {
-			// Use Object.create() to create an object without a prototype to avoid prototype pollution.
-			const exportedGlobalVariables: Record<string, unknown> = Object.create( {} );
-
-			// It can be done sequentially because scripts *should* be loaded at this point and the whole execution should be quite fast.
-			for ( const [ name, pack ] of Object.entries( packs ) ) {
-				exportedGlobalVariables[ name ] = await pack?.getExportedEntries?.();
-			}
-
-			return exportedGlobalVariables as any;
-		}
+		...mergedPacks,
+		getExportedEntries
 	};
 }
 
 /**
  * A map of CKEditor CDN bundles packs.
  */
-type CKCdnBundlesPacks = Record<string, CKCdnResourcesPack<any> | undefined>;
+export type CKCdnBundlesPacks = Record<string, CKCdnResourcesPack<any> | undefined>;
 
 /**
  * A combined pack of resources for multiple CKEditor CDN bundles.
  */
-type CKCdnCombinedBundlePack<P extends CKCdnBundlesPacks> = CKCdnResourcesPack<{
-	[ K in keyof P ]: InferCKCdnResourcesPackExportsType<P[K]>;
+export type CKCdnCombinedBundlePack<P extends CKCdnBundlesPacks> = CKCdnResourcesAdvancedPack<{
+	[ K in keyof P ]: InferCKCdnResourcesPackExportsType<P[K]>
 }>;

--- a/src/cdn/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/combineCKCdnBundlesPacks.ts
@@ -59,13 +59,13 @@ export function combineCKCdnBundlesPacks<P extends CKCdnBundlesPacks>( packs: P 
 		);
 
 	// Get exported entries from all packs.
-	const getExportedEntries = async () => {
+	const confirmPluginReady = async () => {
 		// Use Object.create() to create an object without a prototype to avoid prototype pollution.
 		const exportedGlobalVariables: Record<string, unknown> = Object.create( null );
 
 		// It can be done sequentially because scripts *should* be loaded at this point and the whole execution should be quite fast.
 		for ( const [ name, pack ] of Object.entries( normalizedPacks ) ) {
-			exportedGlobalVariables[ name ] = await pack?.getExportedEntries?.();
+			exportedGlobalVariables[ name ] = await pack?.confirmPluginReady?.();
 		}
 
 		return exportedGlobalVariables as any;
@@ -73,7 +73,7 @@ export function combineCKCdnBundlesPacks<P extends CKCdnBundlesPacks>( packs: P 
 
 	return {
 		...mergedPacks,
-		getExportedEntries
+		confirmPluginReady
 	};
 }
 

--- a/src/cdn/loadCKCdnResourcesPack.ts
+++ b/src/cdn/loadCKCdnResourcesPack.ts
@@ -22,7 +22,7 @@ import { uniq } from '../utils/uniq';
  * 	scripts: [
  * 		'https://cdn.ckeditor.com/ckeditor5/30.0.0/classic/ckeditor.js'
  * 	],
- * 	getExportedEntries: () => ( window as any ).ClassicEditor
+ * 	confirmPluginReady: () => ( window as any ).ClassicEditor
  * } );
  * ```
  */
@@ -31,7 +31,7 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 		scripts = [],
 		stylesheets = [],
 		preload,
-		getExportedEntries
+		confirmPluginReady
 	} = normalizeCKCdnResourcesPack( pack );
 
 	// If preload is not defined, use all stylesheets and scripts as preload resources.
@@ -60,7 +60,7 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 	}
 
 	// Wait for execution all injected scripts.
-	return getExportedEntries?.();
+	return confirmPluginReady?.();
 }
 
 /**
@@ -86,7 +86,7 @@ export function normalizeCKCdnResourcesPack<R = any>( pack: CKCdnResourcesPack<R
 	// Check if it is a local import function, if so, convert it to the advanced format.
 	if ( typeof pack === 'function' ) {
 		return {
-			getExportedEntries: pack
+			confirmPluginReady: pack
 		};
 	}
 
@@ -134,7 +134,7 @@ type CKCdnResourcesBasicUrlsPack = Array<string>;
  * 	scripts: [
  * 		'https://cdn.ckeditor.com/ckeditor5/30.0.0/classic/ckeditor.js'
  * 	],
- * 	getExportedEntries: () => ( window as any ).ClassicEditor
+ * 	confirmPluginReady: () => ( window as any ).ClassicEditor
  * };
  * ```
  */
@@ -158,7 +158,7 @@ export type CKCdnResourcesAdvancedPack<R> = {
 	/**
 	 * Get JS object with global variables exported by scripts.
 	 */
-	getExportedEntries?: () => Awaitable<R>;
+	confirmPluginReady?: () => Awaitable<R>;
 };
 
 /**

--- a/src/cdn/loadCKCdnResourcesPack.ts
+++ b/src/cdn/loadCKCdnResourcesPack.ts
@@ -10,37 +10,6 @@ import { injectStylesheet } from '../utils/injectStylesheet';
 import { preloadResource } from '../utils/preloadResource';
 
 /**
- * A pack of resources to load (scripts and stylesheets) and the exported global variables.
- */
-export type CKCdnResourcesPack<R = any> = {
-
-	/**
-	 * List of resources to preload, it should improve the performance of loading the resources.
-	 */
-	preload?: Array<string>;
-
-	/**
-	 * List of scripts to load. Scripts are loaded in the order they are defined.
-	 */
-	scripts?: Array<string | ( () => Awaitable<unknown> )>;
-
-	/**
-	 * List of stylesheets to load. Stylesheets are loaded in the order they are defined.
-	 */
-	stylesheets?: Array<string>;
-
-	/**
-	 * Get JS object with global variables exported by scripts.
-	 */
-	getExportedEntries?: () => Awaitable<R>;
-};
-
-/**
- * Extracts the type of the exported global variables from a CKResourcesPack.
- */
-export type InferCKCdnResourcesPackExportsType<P> = P extends CKCdnResourcesPack<infer R> ? R : never;
-
-/**
  * Loads pack of resources (scripts and stylesheets) and returns the exported global variables (if any).
  *
  * @param pack The pack of resources to load.
@@ -56,14 +25,14 @@ export type InferCKCdnResourcesPackExportsType<P> = P extends CKCdnResourcesPack
  * } );
  * ```
  */
-export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
-	{
+export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>( pack: P ): Promise<InferCKCdnResourcesPackExportsType<P>> {
+	let {
 		scripts = [],
 		stylesheets = [],
 		preload,
 		getExportedEntries
-	}: P
-): Promise<InferCKCdnResourcesPackExportsType<P>> {
+	} = normalizeCKCdnResourcesPack( pack );
+
 	// If preload is not defined, use all stylesheets and scripts as preload resources.
 	if ( !preload ) {
 		preload = [
@@ -92,3 +61,106 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 	// Wait for execution all injected scripts.
 	return getExportedEntries?.();
 }
+
+/**
+ * Normalizes the CKCdnResourcesPack configuration to the advanced format.
+ *
+ * @param pack The pack of resources to normalize.
+ * @returns The normalized pack of resources.
+ */
+export function normalizeCKCdnResourcesPack<R = any>( pack: CKCdnResourcesPack<R> ): CKCdnResourcesAdvancedPack<R> {
+	// Check if it is array of URLs, if so, convert it to the advanced format.
+	if ( Array.isArray( pack ) ) {
+		return {
+			scripts: pack.filter(
+				item => typeof item === 'function' || item.endsWith( '.js' )
+			),
+
+			stylesheets: pack.filter(
+				item => item.endsWith( '.css' )
+			)
+		};
+	}
+
+	// Check if it is a local import function, if so, convert it to the advanced format.
+	if ( typeof pack === 'function' ) {
+		return {
+			getExportedEntries: pack
+		};
+	}
+
+	// Return the pack as it is, because it's already in the advanced format.
+	return pack;
+}
+
+/**
+ * A pack of resources to load (scripts and stylesheets) and the exported global variables.
+ */
+export type CKCdnResourcesPack<R = any> =
+	| CKCdnResourcesAdvancedPack<R>
+	| CKCdnResourcesBasicUrlsPack
+	| CKCdnResourcesLocalPack<R>;
+
+/**
+ * A pack of resources to load as an async function that results with UMD module.
+ *
+ * @example
+ * ```ts
+ * const pack = async () => import( './your-module' );
+ * ```
+ */
+type CKCdnResourcesLocalPack<R> = () => Awaitable<R>;
+
+/**
+ * A pack of resources to load (scripts and stylesheets). In such configuration, the exported global variable
+ * might be available but it's not guaranteed.
+ *
+ * @example
+ * ```ts
+ * const pack = [
+ * 	'https://cdn.ckeditor.com/ckeditor5/30.0.0/classic/ckeditor.js'
+ * ];
+ * ```
+ */
+type CKCdnResourcesBasicUrlsPack = Array<string>;
+
+/**
+ * A pack of resources to load (scripts and stylesheets) and the exported global variables.
+ *
+ * @example
+ * ```ts
+ * const pack = {
+ * 	scripts: [
+ * 		'https://cdn.ckeditor.com/ckeditor5/30.0.0/classic/ckeditor.js'
+ * 	],
+ * 	getExportedEntries: () => ( window as any ).ClassicEditor
+ * };
+ * ```
+ */
+export type CKCdnResourcesAdvancedPack<R> = {
+
+	/**
+	 * List of resources to preload, it should improve the performance of loading the resources.
+	 */
+	preload?: Array<string>;
+
+	/**
+	 * List of scripts to load. Scripts are loaded in the order they are defined.
+	 */
+	scripts?: Array<string | ( () => Awaitable<unknown> )>;
+
+	/**
+	 * List of stylesheets to load. Stylesheets are loaded in the order they are defined.
+	 */
+	stylesheets?: Array<string>;
+
+	/**
+	 * Get JS object with global variables exported by scripts.
+	 */
+	getExportedEntries?: () => Awaitable<R>;
+};
+
+/**
+ * Extracts the type of the exported global variables from a CKResourcesPack.
+ */
+export type InferCKCdnResourcesPackExportsType<P> = P extends CKCdnResourcesPack<infer R> ? R : never;

--- a/src/cdn/loadCKCdnResourcesPack.ts
+++ b/src/cdn/loadCKCdnResourcesPack.ts
@@ -8,6 +8,7 @@ import type { Awaitable } from '../types/Awaitable';
 import { injectScript } from '../utils/injectScript';
 import { injectStylesheet } from '../utils/injectStylesheet';
 import { preloadResource } from '../utils/preloadResource';
+import { uniq } from '../utils/uniq';
 
 /**
  * Loads pack of resources (scripts and stylesheets) and returns the exported global variables (if any).
@@ -35,10 +36,10 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 
 	// If preload is not defined, use all stylesheets and scripts as preload resources.
 	if ( !preload ) {
-		preload = [
+		preload = uniq( [
 			...stylesheets.filter( item => typeof item === 'string' ),
 			...scripts.filter( item => typeof item === 'string' )
-		];
+		] );
 	}
 
 	// Preload resources specified in the pack.
@@ -46,11 +47,11 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 
 	// Load stylesheet tags before scripts to avoid flash of unstyled content.
 	await Promise.all(
-		stylesheets.map( injectStylesheet )
+		uniq( stylesheets ).map( injectStylesheet )
 	);
 
 	// Load script tags.
-	for ( const script of scripts ) {
+	for ( const script of uniq( scripts ) ) {
 		if ( typeof script === 'string' ) {
 			await injectScript( script );
 		} else {

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -64,13 +64,13 @@ import {
  * 			stylesheets: [ 'https://cdn.example.com/plugin3.css' ],
  *
  * 			// Optional, if it's not passed then the type of `Plugin3` will be picked from `Window`
- * 			getExportedEntries: () => ( window as any ).Plugin3
+ * 			confirmPluginReady: () => ( window as any ).Plugin3
  * 		}
  * 	}
  * } );
  * ```
  *
- * Type of plugins can be inferred if `getExportedEntries` is not provided: In this case,
+ * Type of plugins can be inferred if `confirmPluginReady` is not provided: In this case,
  * the type of the plugin will be picked from the global window scope.
  */
 export function loadCKEditorCloud<Plugins extends CKCdnBundlesPacks>(

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -5,7 +5,12 @@
 
 import { createCKCdnBaseBundlePack } from './ck/createCKCdnBaseBundlePack';
 import { createCKCdnPremiumBundlePack } from './ck/createCKCdnPremiumBundlePack';
-import { combineCKCdnBundlesPacks } from './combineCKCdnBundlesPacks';
+
+import {
+	combineCKCdnBundlesPacks,
+	type CKCdnBundlesPacks
+} from './combineCKCdnBundlesPacks';
+
 import {
 	createCKBoxBundlePack,
 	type CKBoxCdnBundlePackConfig
@@ -14,9 +19,13 @@ import {
 import type { CKCdnVersion } from './ck/createCKCdnUrl';
 import {
 	loadCKCdnResourcesPack,
-	type CKCdnResourcesPack,
 	type InferCKCdnResourcesPackExportsType
 } from './loadCKCdnResourcesPack';
+
+import {
+	combineCdnPluginsPacks,
+	type CombinedPluginsPackWithFallbackScope
+} from './plugins/combineCdnPluginsPacks';
 
 /**
  * A composable function that loads CKEditor Cloud Services bundles.
@@ -24,8 +33,10 @@ import {
  *
  * @param config The configuration of the CKEditor Cloud Services bundles to load.
  * @returns The result of the loaded CKEditor Cloud Services bundles.
- * @template A The type of the additional resources to load.
  * @example
+ *
+ * Example of loading CKEditor Cloud Services with the premium features and CKBox:
+ *
  * ```ts
  * const { CKEditor, CKEditorPremiumFeatures } = await loadCKEditorCloud( {
  * 	version: '43.0.0',
@@ -36,10 +47,35 @@ import {
  * const { Paragraph } = CKEditor;
  * const { SlashCommands } = CKEditorPremiumFeatures;
  * ```
+ *
+ * Example of loading CKEditor Cloud Services with custom plugins:
+ *
+ * ```ts
+ * const { CKEditor, loadedPlugins } = await loadCKEditorCloud( {
+ * 	version: '43.0.0',
+ * 	plugins: {
+ * 		Plugin1: async () => import( './your-local-import.umd.js' ),
+ * 		Plugin2: [
+ * 			'https://cdn.example.com/plugin2.js',
+ * 			'https://cdn.example.com/plugin2.css'
+ * 		],
+ * 		Plugin3: {
+ * 			scripts: [ 'https://cdn.example.com/plugin3.js' ],
+ * 			stylesheets: [ 'https://cdn.example.com/plugin3.css' ],
+ *
+ * 			// Optional, if it's not passed then the type of `Plugin3` will be picked from `Window`
+ * 			getExportedEntries: () => ( window as any ).Plugin3
+ * 		}
+ * 	}
+ * } );
+ * ```
+ *
+ * Type of plugins can be inferred if `getExportedEntries` is not provided: In this case,
+ * the type of the plugin will be picked from the global window scope.
  */
-export function loadCKEditorCloud<A extends CKExternalPluginsMap>(
-	config: CKEditorCloudConfig<A>
-): Promise<CKEditorCloudResult<A>> {
+export function loadCKEditorCloud<Plugins extends CKCdnBundlesPacks>(
+	config: CKEditorCloudConfig<Plugins>
+): Promise<CKEditorCloudResult<Plugins>> {
 	const {
 		version, languages, plugins,
 		premium, ckbox
@@ -62,25 +98,16 @@ export function loadCKEditorCloud<A extends CKExternalPluginsMap>(
 			CKBox: createCKBoxBundlePack( ckbox )
 		},
 
-		...plugins && {
-			CKPlugins: combineCKCdnBundlesPacks( plugins )
-		}
+		loadedPlugins: combineCdnPluginsPacks( plugins ?? {} )
 	} );
 
-	return loadCKCdnResourcesPack( pack ) as Promise<CKEditorCloudResult<A>>;
+	return loadCKCdnResourcesPack( pack ) as Promise<CKEditorCloudResult<Plugins>>;
 }
 
 /**
- * `plugins` property of the `CKEditorCloudConfig`.
- */
-export type CKExternalPluginsMap = Record<string, CKCdnResourcesPack<any>>;
-
-/**
  * The result of the resolved bundles from CKEditor Cloud Services.
- *
- * @template A The type of the additional resources to load.
  */
-export type CKEditorCloudResult<A extends CKExternalPluginsMap = any> = {
+export type CKEditorCloudResult<Plugins extends CKCdnBundlesPacks = any> = {
 
 	/**
 	 * The base CKEditor bundle exports.
@@ -100,17 +127,15 @@ export type CKEditorCloudResult<A extends CKExternalPluginsMap = any> = {
 	/**
 	 * The additional resources exports.
 	 */
-	CKPlugins?: {
-		[ K in keyof A ]: InferCKCdnResourcesPackExportsType<A[K]>
-	};
+	loadedPlugins: InferCKCdnResourcesPackExportsType<
+		CombinedPluginsPackWithFallbackScope<Plugins>
+	>;
 };
 
 /**
  * The configuration of the `useCKEditorCloud` hook.
- *
- * @template A The type of the additional resources to load.
  */
-export type CKEditorCloudConfig<A extends CKExternalPluginsMap = CKExternalPluginsMap> = {
+export type CKEditorCloudConfig<Plugins extends CKCdnBundlesPacks = CKCdnBundlesPacks> = {
 
 	/**
 	 * The version of CKEditor Cloud Services to use.
@@ -135,5 +160,5 @@ export type CKEditorCloudConfig<A extends CKExternalPluginsMap = CKExternalPlugi
 	/**
 	 * Additional resources to load.
 	 */
-	plugins?: A;
+	plugins?: Plugins;
 };

--- a/src/cdn/plugins/combineCdnPluginsPacks.ts
+++ b/src/cdn/plugins/combineCdnPluginsPacks.ts
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { mapObjectValues } from '../../utils/mapObjectValues';
+import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
+
+import {
+	normalizeCKCdnResourcesPack,
+	type InferCKCdnResourcesPackExportsType,
+	type CKCdnResourcesAdvancedPack
+} from '../loadCKCdnResourcesPack';
+
+import {
+	combineCKCdnBundlesPacks,
+	type CKCdnBundlesPacks
+} from '../combineCKCdnBundlesPacks';
+
+/**
+ * This function is similar to `combineCKCdnBundlesPacks` but it provides global scope
+ * fallback for the plugins that do not define the type of the exported entries. In other
+ * words if the plugin `Reader` does not define the type of the exported entries, the type
+ * will be picked from the `Window[ 'Reader' ]` object.
+ *
+ * @param pluginsPacks A map of CKEditor plugins packs.
+ * @returns A combined pack of resources for multiple CKEditor plugins.
+ * @example
+ *
+ * ```ts
+ * const { ScreenReader, AccessibilityChecker } = await loadCKCdnResourcesPack(
+ * 	combineCdnPluginsPacks( {
+ * 		ScreenReader: [ 'https://example.org/screen-reader.js' ],
+ * 		AccessibilityChecker: [ 'https://example.org/accessibility-checker.js' ]
+ * 	} )
+ * );
+ * ```
+ *
+ * In example above, `ScreenReader` and `AccessibilityChecker` are the plugins names and
+ * the type of the exported entries will be picked from the global (Window) scope.
+ */
+export function combineCdnPluginsPacks<Plugins extends CKCdnBundlesPacks>(
+	pluginsPacks: Plugins
+): CombinedPluginsPackWithFallbackScope<Plugins> {
+	const normalizedPluginsPacks = mapObjectValues( pluginsPacks, ( pluginPack, pluginName ) => {
+		if ( !pluginPack ) {
+			return undefined;
+		}
+
+		const normalizedPluginPack = normalizeCKCdnResourcesPack( pluginPack );
+
+		return {
+			// Provide default window accessor object if the plugin pack does not define it.
+			getExportedEntries: async (): Promise<unknown> =>
+				waitForWindowEntry( [ pluginName as any ] ),
+
+			// Transform the plugin pack to a normalized advanced pack.
+			...normalizedPluginPack
+		};
+	} );
+
+	// Merge all scripts, stylesheets and preload resources from all packs.
+	return combineCKCdnBundlesPacks(
+		normalizedPluginsPacks
+	) as CombinedPluginsPackWithFallbackScope<Plugins>;
+}
+
+/**
+ * A combined pack of plugins. It picks the type of the plugin from the global scope if
+ * `CKCdnCombinedBundlePack` does not define it in the `getExportedEntries` method.
+ */
+export type CombinedPluginsPackWithFallbackScope<P extends CKCdnBundlesPacks> = CKCdnResourcesAdvancedPack<{
+	[ K in keyof P ]: FallbackIfUnknown<
+		InferCKCdnResourcesPackExportsType<P[K]>,
+		K extends keyof Window ? Window[ K ] : unknown
+	>;
+}>;
+
+/**
+ * Returns the fallback type if the provided type is unknown.
+ */
+type FallbackIfUnknown<T, Fallback> = unknown extends T ? Fallback : T;

--- a/src/cdn/plugins/combineCdnPluginsPacks.ts
+++ b/src/cdn/plugins/combineCdnPluginsPacks.ts
@@ -51,7 +51,7 @@ export function combineCdnPluginsPacks<Plugins extends CKCdnBundlesPacks>(
 
 		return {
 			// Provide default window accessor object if the plugin pack does not define it.
-			getExportedEntries: async (): Promise<unknown> =>
+			confirmPluginReady: async (): Promise<unknown> =>
 				waitForWindowEntry( [ pluginName as any ] ),
 
 			// Transform the plugin pack to a normalized advanced pack.
@@ -67,7 +67,7 @@ export function combineCdnPluginsPacks<Plugins extends CKCdnBundlesPacks>(
 
 /**
  * A combined pack of plugins. It picks the type of the plugin from the global scope if
- * `CKCdnCombinedBundlePack` does not define it in the `getExportedEntries` method.
+ * `CKCdnCombinedBundlePack` does not define it in the `confirmPluginReady` method.
  */
 export type CombinedPluginsPackWithFallbackScope<P extends CKCdnBundlesPacks> = CKCdnResourcesAdvancedPack<{
 	[ K in keyof P ]: FallbackIfUnknown<

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ export { shallowCompareArrays } from './utils/shallowCompareArrays';
 export { uid } from './utils/uid';
 export { uniq } from './utils/uniq';
 export { waitForWindowEntry } from './utils/waitForWindowEntry';
+export { filterObjectValues } from './utils/filterObjectValues';
+export { filterBlankObjectValues } from './utils/filterBlankObjectValues';
+export { mapObjectValues } from './utils/mapObjectValues';
 
 export {
 	CK_CDN_URL,
@@ -36,6 +39,5 @@ export {
 export {
 	loadCKEditorCloud,
 	type CKEditorCloudConfig,
-	type CKEditorCloudResult,
-	type CKExternalPluginsMap
+	type CKEditorCloudResult
 } from './cdn/loadCKEditorCloud';

--- a/src/utils/filterBlankObjectValues.ts
+++ b/src/utils/filterBlankObjectValues.ts
@@ -1,0 +1,35 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { filterObjectValues } from './filterObjectValues';
+
+/**
+ * Removes null and undefined values from an object.
+ *
+ * @param obj Object to filter.
+ * @returns Object with filtered values.
+ * @example
+ * ```ts
+ * const obj = {
+ * 	a: 1,
+ * 	b: null,
+ * 	c: undefined
+ * };
+ *
+ * const filteredObj = filterBlankObjectValues( obj );
+ * // filteredObj is { a: 1 }
+ * ```
+ */
+export function filterBlankObjectValues<T>( obj: Record<string, T> ): FilterBlankRecordProperties<T> {
+	return filterObjectValues(
+		obj,
+		value => value !== null && value !== undefined
+	) as FilterBlankRecordProperties<T>;
+}
+
+/**
+ * Removes null and undefined values from an object.
+ */
+type FilterBlankRecordProperties<T> = Record<string, Exclude<T, null | undefined>>;

--- a/src/utils/filterObjectValues.ts
+++ b/src/utils/filterObjectValues.ts
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Filters object values using the provided filter function.
+ *
+ * @param obj Object to filter.
+ * @param filter Function that filters the object values.
+ * @returns Object with filtered values.
+ *
+ * @example
+ * ```ts
+ * const obj = {
+ * 	a: 1,
+ * 	b: 2
+ * };
+ *
+ * const filteredObj = filterObjectValues( value => value > 1, obj );
+ * // filteredObj is { b: 2 }
+ * ```
+ */
+export function filterObjectValues<T>(
+	obj: Record<string, T>,
+	filter: ( value: T, key: string ) => boolean
+): Record<string, T> {
+	const filteredEntries = Object
+		.entries( obj )
+		.filter( ( [ key, value ] ) => filter( value, key ) );
+
+	return Object.fromEntries( filteredEntries );
+}

--- a/src/utils/injectScript.ts
+++ b/src/utils/injectScript.ts
@@ -39,7 +39,7 @@ export function injectScript( src: string ): Promise<void> {
 			resolve();
 		};
 
-		script.setAttribute( 'injected-by', 'ckeditor-integration' );
+		script.setAttribute( 'data-injected-by', 'ckeditor-integration' );
 		script.type = 'text/javascript';
 		script.async = true;
 		script.src = src;

--- a/src/utils/injectStylesheet.ts
+++ b/src/utils/injectStylesheet.ts
@@ -34,7 +34,7 @@ export function injectStylesheet( href: string ): Promise<void> {
 	const promise = new Promise<void>( ( resolve, reject ) => {
 		const link = document.createElement( 'link' );
 
-		link.setAttribute( 'injected-by', 'ckeditor-integration' );
+		link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
 		link.rel = 'stylesheet';
 		link.href = href;
 

--- a/src/utils/mapObjectValues.ts
+++ b/src/utils/mapObjectValues.ts
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Maps object values using the provided mapper function.
+ *
+ * @param obj Object to map.
+ * @param mapper Function that maps the object values.
+ * @returns Object with mapped values.
+ *
+ * @example
+ * ```ts
+ * const obj = {
+ * 	a: 1,
+ * 	b: 2
+ * };
+ *
+ * const mappedObj = mapObjectValues( obj, value => value * 2 );
+ * // mappedObj is { a: 2, b: 4 }
+ * ```
+ */
+export function mapObjectValues<T, U>(
+	obj: Record<string, T>,
+	mapper: ( value: T, key: string ) => U
+): Record<string, U> {
+	const mappedEntries = Object
+		.entries( obj )
+		.map( ( [ key, value ] ) => [ key, mapper( value, key ) ] as const );
+
+	return Object.fromEntries( mappedEntries );
+}

--- a/src/utils/preloadResource.ts
+++ b/src/utils/preloadResource.ts
@@ -16,7 +16,7 @@ export function preloadResource( url: string ): void {
 
 	const link = document.createElement( 'link' );
 
-	link.setAttribute( 'injected-by', 'ckeditor-integration' );
+	link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
 	link.rel = 'preload';
 	link.as = detectTypeOfResource( url );
 	link.href = url;

--- a/tests/_utils/index.ts
+++ b/tests/_utils/index.ts
@@ -6,3 +6,4 @@
 export * from './ckBoxCdnMocks';
 export * from './ckCdnMocks';
 export * from './removeAllCkCdnResources';
+export * from './queryHeadElement';

--- a/tests/_utils/queryHeadElement.ts
+++ b/tests/_utils/queryHeadElement.ts
@@ -1,0 +1,25 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Queries a link element with the given `href` attribute.
+ */
+export function queryStylesheet( href: string ): HTMLLinkElement | null {
+	return document.querySelector( `head > link[rel="stylesheet"][href="${ href }"]` );
+}
+
+/**
+ * Queries a preload link element with the given `href` attribute.
+ */
+export function queryPreload( href: string ): HTMLLinkElement | null {
+	return document.querySelector( `head > link[rel="preload"][href="${ href }"]` );
+}
+
+/**
+ * Queries a script element with the given `src` attribute.
+ */
+export function queryScript( src: string ): HTMLScriptElement | null {
+	return document.querySelector( `head > script[src="${ src }"]` );
+}

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -32,7 +32,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 			'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.css'
 		] );
 
-		expect( pack.getExportedEntries ).toBeInstanceOf( Function );
+		expect( pack.confirmPluginReady ).toBeInstanceOf( Function );
 	} );
 
 	it( 'should not load any language if not provided', () => {
@@ -41,7 +41,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 		} );
 
 		expect( pack ).to.toMatchObject( {
-			getExportedEntries: expect.any( Function ),
+			confirmPluginReady: expect.any( Function ),
 			stylesheets: [
 				'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.css'
 			],

--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -25,7 +25,7 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css'
 		] );
 
-		expect( pack.getExportedEntries ).toBeInstanceOf( Function );
+		expect( pack.confirmPluginReady ).toBeInstanceOf( Function );
 	} );
 
 	it( 'should not load any language if not provided', () => {
@@ -34,7 +34,7 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 		} );
 
 		expect( pack ).to.toMatchObject( {
-			getExportedEntries: expect.any( Function ),
+			confirmPluginReady: expect.any( Function ),
 			stylesheets: [
 				'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css'
 			],

--- a/tests/cdn/ckbox/createCKBoxBundlePack.test.ts
+++ b/tests/cdn/ckbox/createCKBoxBundlePack.test.ts
@@ -19,7 +19,7 @@ describe( 'createCKBoxBundlePack', () => {
 			stylesheets: [
 				'https://cdn.ckbox.io/ckbox/2.5.1/styles/themes/lark.css'
 			],
-			getExportedEntries: expect.any( Function )
+			confirmPluginReady: expect.any( Function )
 		} );
 	} );
 } );

--- a/tests/cdn/combineCKCdnBundlesPacks.test.ts
+++ b/tests/cdn/combineCKCdnBundlesPacks.test.ts
@@ -12,14 +12,14 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			preload: [ 'preload1' ],
 			scripts: [ 'script1' ],
 			stylesheets: [ 'stylesheet1' ],
-			getExportedEntries: async () => ( { exported1: 'value1' } )
+			confirmPluginReady: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			preload: [ 'preload2' ],
 			scripts: [ 'script2' ],
 			stylesheets: [ 'stylesheet2' ],
-			getExportedEntries: async () => ( { exported2: 'value2' } )
+			confirmPluginReady: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -33,7 +33,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1', 'stylesheet2' ]
 		} );
 
-		const exportedEntries = await combinedPack.getExportedEntries!();
+		const exportedEntries = await combinedPack.confirmPluginReady!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -46,7 +46,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			preload: [ 'preload1' ],
 			scripts: [ 'script1' ],
 			stylesheets: [ 'stylesheet1' ],
-			getExportedEntries: async () => ( { exported1: 'value1' } )
+			confirmPluginReady: async () => ( { exported1: 'value1' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -60,7 +60,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1' ]
 		} );
 
-		const exportedEntries = await combinedPack.getExportedEntries!();
+		const exportedEntries = await combinedPack.confirmPluginReady!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -77,7 +77,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: []
 		} );
 
-		const exportedEntries = await combinedPack.getExportedEntries!();
+		const exportedEntries = await combinedPack.confirmPluginReady!();
 
 		expect( exportedEntries ).toEqual( {} );
 	} );
@@ -86,13 +86,13 @@ describe( 'combineCKCdnBundlesPacks', () => {
 		const pack1 = {
 			preload: [ 'preload1' ],
 			stylesheets: [ 'stylesheet1' ],
-			getExportedEntries: async () => ( { exported1: 'value1' } )
+			confirmPluginReady: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			preload: [ 'preload2' ],
 			stylesheets: [ 'stylesheet2' ],
-			getExportedEntries: async () => ( { exported2: 'value2' } )
+			confirmPluginReady: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -105,7 +105,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1', 'stylesheet2' ]
 		} );
 
-		const exportedEntries = await combinedPack.getExportedEntries!();
+		const exportedEntries = await combinedPack.confirmPluginReady!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -117,13 +117,13 @@ describe( 'combineCKCdnBundlesPacks', () => {
 		const pack1 = {
 			preload: [ 'preload1' ],
 			scripts: [ 'script1' ],
-			getExportedEntries: async () => ( { exported1: 'value1' } )
+			confirmPluginReady: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			preload: [ 'preload2' ],
 			scripts: [ 'script2' ],
-			getExportedEntries: async () => ( { exported2: 'value2' } )
+			confirmPluginReady: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -136,7 +136,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			scripts: [ 'script1', 'script2' ]
 		} );
 
-		const exportedEntries = await combinedPack.getExportedEntries!();
+		const exportedEntries = await combinedPack.confirmPluginReady!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -148,13 +148,13 @@ describe( 'combineCKCdnBundlesPacks', () => {
 		const pack1 = {
 			scripts: [ 'script1' ],
 			stylesheets: [ 'stylesheet1' ],
-			getExportedEntries: async () => ( { exported1: 'value1' } )
+			confirmPluginReady: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			scripts: [ 'script2' ],
 			stylesheets: [ 'stylesheet2' ],
-			getExportedEntries: async () => ( { exported2: 'value2' } )
+			confirmPluginReady: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -167,7 +167,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1', 'stylesheet2' ]
 		} );
 
-		const exportedEntries = await combinedPack.getExportedEntries!();
+		const exportedEntries = await combinedPack.confirmPluginReady!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },

--- a/tests/cdn/loadCKCdnResourcesPack.test.ts
+++ b/tests/cdn/loadCKCdnResourcesPack.test.ts
@@ -29,14 +29,14 @@ describe( 'loadCKCdnResourcesPack', () => {
 	} );
 
 	it( 'should return the exported global variables', async () => {
-		const getExportedEntries = vitest.fn( () => ( {
+		const confirmPluginReady = vitest.fn( () => ( {
 			ClassicEditor: {
 				version: '30.0.0'
 			}
 		} ) );
 
 		const result = await loadCKCdnResourcesPack( {
-			getExportedEntries
+			confirmPluginReady
 		} );
 
 		expect( result ).toEqual( {
@@ -45,7 +45,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 			}
 		} );
 
-		expect( getExportedEntries ).toHaveBeenCalled();
+		expect( confirmPluginReady ).toHaveBeenCalled();
 	} );
 
 	it( 'should not inject any script if the pack does not contain any', async () => {
@@ -56,7 +56,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 		};
 
 		const loaded = await loadCKCdnResourcesPack( {
-			getExportedEntries: () => result
+			confirmPluginReady: () => result
 		} );
 
 		expect( result ).toEqual( loaded );
@@ -65,7 +65,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 	it( 'should inject the script if the pack contains one', async () => {
 		const loaded = await loadCKCdnResourcesPack( {
 			scripts: [ CDN_MOCK_SCRIPT_URL ],
-			getExportedEntries: () => window.CKEDITOR!
+			confirmPluginReady: () => window.CKEDITOR!
 		} );
 
 		expect( loaded ).toBeDefined();
@@ -94,7 +94,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 	it( 'should use preload property instead default one if passed', async () => {
 		const loaded = await loadCKCdnResourcesPack( {
 			preload: [ CDN_MOCK_SCRIPT_URL ],
-			getExportedEntries: () => ( {
+			confirmPluginReady: () => ( {
 				result: 2
 			} )
 		} );
@@ -107,7 +107,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 		const loaded = await loadCKCdnResourcesPack( {
 			scripts: [ CDN_MOCK_SCRIPT_URL ],
 			stylesheets: [ CDN_MOCK_STYLESHEET_URL ],
-			getExportedEntries: () => ( {
+			confirmPluginReady: () => ( {
 				result: 2
 			} )
 		} );
@@ -124,7 +124,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 
 		await loadCKCdnResourcesPack( {
 			scripts: [ customFunction ],
-			getExportedEntries: () => ( {
+			confirmPluginReady: () => ( {
 				result: 2
 			} )
 		} );

--- a/tests/cdn/loadCKCdnResourcesPack.test.ts
+++ b/tests/cdn/loadCKCdnResourcesPack.test.ts
@@ -7,11 +7,14 @@ import { describe, it, vi, expect, vitest, beforeEach, afterEach } from 'vitest'
 
 import { loadCKCdnResourcesPack } from '@/cdn/loadCKCdnResourcesPack';
 import {
+	queryScript,
+	queryStylesheet,
+	queryPreload,
 	removeCkCdnLinks,
 	removeCkCdnScripts,
 	CDN_MOCK_SCRIPT_URL,
 	CDN_MOCK_STYLESHEET_URL
-} from 'tests/_utils/ckCdnMocks';
+} from 'tests/_utils';
 
 describe( 'loadCKCdnResourcesPack', () => {
 	beforeEach( () => {
@@ -69,6 +72,25 @@ describe( 'loadCKCdnResourcesPack', () => {
 		expect( loaded ).toEqual( window.CKEDITOR );
 	} );
 
+	it( 'should be possible to define pack using plain array of scripts and stylesheets', async () => {
+		expect( queryScript( CDN_MOCK_SCRIPT_URL ) ).toBeNull();
+		expect( queryStylesheet( CDN_MOCK_STYLESHEET_URL ) ).toBeNull();
+
+		await loadCKCdnResourcesPack( [
+			CDN_MOCK_SCRIPT_URL,
+			CDN_MOCK_STYLESHEET_URL
+		] );
+
+		expect( queryScript( CDN_MOCK_SCRIPT_URL ) ).not.toBeNull();
+		expect( queryStylesheet( CDN_MOCK_STYLESHEET_URL ) ).not.toBeNull();
+	} );
+
+	it( 'should be possible to define pack using plain async function', async () => {
+		const pack = await loadCKCdnResourcesPack( async () => ( { a: 2 } ) );
+
+		expect( pack ).toEqual( { a: 2 } );
+	} );
+
 	it( 'should use preload property instead default one if passed', async () => {
 		const loaded = await loadCKCdnResourcesPack( {
 			preload: [ CDN_MOCK_SCRIPT_URL ],
@@ -78,7 +100,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 		} );
 
 		expect( loaded ).toBeDefined();
-		expect( document.querySelector( `link[rel="preload"][href="${ CDN_MOCK_SCRIPT_URL }"]` ) ).not.toBeNull();
+		expect( queryPreload( CDN_MOCK_SCRIPT_URL ) ).not.toBeNull();
 	} );
 
 	it( 'should automatically preload all resources if preload property is not defined', async () => {
@@ -93,7 +115,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 		expect( loaded ).toBeDefined();
 
 		for ( const link of [ CDN_MOCK_SCRIPT_URL, CDN_MOCK_STYLESHEET_URL ] ) {
-			expect( document.querySelector( `link[rel="preload"][href="${ link }"]` ) ).not.toBeNull();
+			expect( queryPreload( link ) ).not.toBeNull();
 		}
 	} );
 

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -77,7 +77,7 @@ describe( 'loadCKEditorCloud', () => {
 	} );
 
 	describe( 'plugins', () => {
-		it( 'should properly infer type of global variable if getExportedEntries is not provided', async () => {
+		it( 'should properly infer type of global variable if confirmPluginReady is not provided', async () => {
 			const { loadedPlugins } = await loadCKEditorCloud( {
 				version: '43.0.0',
 				plugins: {
@@ -88,13 +88,13 @@ describe( 'loadCKEditorCloud', () => {
 			expectTypeOf( loadedPlugins.FakePlugin ).toEqualTypeOf<FakePlugin>();
 		} );
 
-		it( 'should properly infer type of global variable if getExportedEntries is provided', async () => {
+		it( 'should properly infer type of global variable if confirmPluginReady is provided', async () => {
 			const { loadedPlugins } = await loadCKEditorCloud( {
 				version: '43.0.0',
 				plugins: {
 					FakePlugin: {
 						scripts: [ createCKBoxCdnUrl( 'ckbox', 'ckbox.js', '2.5.1' ) ],
-						getExportedEntries: () => window.FakePlugin2
+						confirmPluginReady: () => window.FakePlugin2
 					}
 				}
 			} );

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -3,11 +3,15 @@
  * For licensing, see LICENSE.md.
  */
 
-import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest';
+import {
+	describe, it, vi, expect,
+	expectTypeOf, beforeEach, afterEach
+} from 'vitest';
 
 import { loadCKEditorCloud } from '@/cdn/loadCKEditorCloud';
 import { createCKBoxBundlePack } from '@/cdn/ckbox/createCKBoxCdnBundlePack';
 import { removeCkCdnLinks, removeCkCdnScripts } from 'tests/_utils/ckCdnMocks';
+import { createCKBoxCdnUrl } from '@/src/cdn/ckbox/createCKBoxCdnUrl';
 
 describe( 'loadCKEditorCloud', () => {
 	beforeEach( () => {
@@ -15,6 +19,7 @@ describe( 'loadCKEditorCloud', () => {
 		removeCkCdnLinks();
 
 		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
+		window.FakePlugin = { fake: 'fake' };
 	} );
 
 	afterEach( () => {
@@ -58,7 +63,7 @@ describe( 'loadCKEditorCloud', () => {
 	} );
 
 	it( 'should be possible to load custom plugins', async () => {
-		const { CKEditor, CKPlugins } = await loadCKEditorCloud( {
+		const { CKEditor, loadedPlugins } = await loadCKEditorCloud( {
 			version: '43.0.0',
 			plugins: {
 				Plugin: createCKBoxBundlePack( {
@@ -68,6 +73,48 @@ describe( 'loadCKEditorCloud', () => {
 		} );
 
 		expect( CKEditor.ClassicEditor ).toBeDefined();
-		expect( CKPlugins?.Plugin ).toBeDefined();
+		expect( loadedPlugins?.Plugin ).toBeDefined();
+	} );
+
+	describe( 'plugins', () => {
+		it( 'should properly infer type of global variable if getExportedEntries is not provided', async () => {
+			const { loadedPlugins } = await loadCKEditorCloud( {
+				version: '43.0.0',
+				plugins: {
+					FakePlugin: [ createCKBoxCdnUrl( 'ckbox', 'ckbox.js', '2.5.1' ) ]
+				}
+			} );
+
+			expectTypeOf( loadedPlugins.FakePlugin ).toEqualTypeOf<FakePlugin>();
+		} );
+
+		it( 'should properly infer type of global variable if getExportedEntries is provided', async () => {
+			const { loadedPlugins } = await loadCKEditorCloud( {
+				version: '43.0.0',
+				plugins: {
+					FakePlugin: {
+						scripts: [ createCKBoxCdnUrl( 'ckbox', 'ckbox.js', '2.5.1' ) ],
+						getExportedEntries: () => window.FakePlugin2
+					}
+				}
+			} );
+
+			expectTypeOf( loadedPlugins.FakePlugin ).toEqualTypeOf<FakePlugin2>();
+		} );
 	} );
 } );
+
+type FakePlugin = {
+	fake: string;
+};
+
+type FakePlugin2 = {
+	abc: number;
+};
+
+declare global {
+	interface Window {
+		FakePlugin: FakePlugin;
+		FakePlugin2: FakePlugin2;
+	}
+}

--- a/tests/cdn/plugins/combineCKPluginsPacks.test.ts
+++ b/tests/cdn/plugins/combineCKPluginsPacks.test.ts
@@ -19,7 +19,7 @@ describe( 'combineCdnPluginsPacks', () => {
 		delete window.ScreenReader;
 	} );
 
-	it( 'should define default `getExportedEntries` if not present', async () => {
+	it( 'should define default `confirmPluginReady` if not present', async () => {
 		const combinedPack = combineCdnPluginsPacks( {
 			ScreenReader: [ 'https://example.org/screen-reader.js' ],
 			AccessibilityChecker: undefined
@@ -29,15 +29,15 @@ describe( 'combineCdnPluginsPacks', () => {
 			scripts: [ 'https://example.org/screen-reader.js' ],
 			preload: [],
 			stylesheets: [],
-			getExportedEntries: expect.any( Function )
+			confirmPluginReady: expect.any( Function )
 		} );
 
-		expectTypeOf( combinedPack.getExportedEntries!()! ).toEqualTypeOf<Awaitable<{
+		expectTypeOf( combinedPack.confirmPluginReady!()! ).toEqualTypeOf<Awaitable<{
 			ScreenReader: ScreenReader | undefined;
 			AccessibilityChecker: never;
 		}>>();
 
-		await expect( combinedPack.getExportedEntries!() ).resolves.toEqual( {
+		await expect( combinedPack.confirmPluginReady!() ).resolves.toEqual( {
 			ScreenReader: {
 				test: 123
 			}

--- a/tests/cdn/plugins/combineCKPluginsPacks.test.ts
+++ b/tests/cdn/plugins/combineCKPluginsPacks.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, expectTypeOf } from 'vitest';
+
+import type { Awaitable } from '@/src/types/Awaitable';
+import { combineCdnPluginsPacks } from '@/cdn/plugins/combineCdnPluginsPacks';
+
+describe( 'combineCdnPluginsPacks', () => {
+	beforeEach( () => {
+		window.ScreenReader = {
+			test: 123
+		};
+	} );
+
+	afterEach( () => {
+		delete window.ScreenReader;
+	} );
+
+	it( 'should define default `getExportedEntries` if not present', async () => {
+		const combinedPack = combineCdnPluginsPacks( {
+			ScreenReader: [ 'https://example.org/screen-reader.js' ],
+			AccessibilityChecker: undefined
+		} );
+
+		expect( combinedPack ).toEqual( {
+			scripts: [ 'https://example.org/screen-reader.js' ],
+			preload: [],
+			stylesheets: [],
+			getExportedEntries: expect.any( Function )
+		} );
+
+		expectTypeOf( combinedPack.getExportedEntries!()! ).toEqualTypeOf<Awaitable<{
+			ScreenReader: ScreenReader | undefined;
+			AccessibilityChecker: never;
+		}>>();
+
+		await expect( combinedPack.getExportedEntries!() ).resolves.toEqual( {
+			ScreenReader: {
+				test: 123
+			}
+		} );
+	} );
+} );
+
+type ScreenReader = {
+	test: number;
+};
+
+declare global {
+	interface Window {
+		ScreenReader?: ScreenReader;
+	}
+}

--- a/tests/utils/filterBlankObjectValues.test.ts
+++ b/tests/utils/filterBlankObjectValues.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { filterBlankObjectValues } from '@/src/utils/filterBlankObjectValues';
+
+describe( 'filterBlankObjectValues', () => {
+	it( 'should filter object values that are empty', () => {
+		const obj = {
+			a: 1,
+			b: null,
+			c: undefined,
+			d: []
+		};
+
+		const filteredObj = filterBlankObjectValues( obj );
+
+		expect( filteredObj ).toEqual( {
+			a: 1,
+			d: []
+		} );
+	} );
+} );

--- a/tests/utils/filterObjectValues.test.ts
+++ b/tests/utils/filterObjectValues.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { filterObjectValues } from '@/src/utils/filterObjectValues';
+
+describe( 'filterObjectValues', () => {
+	it( 'should filter object values using the provided filter function', () => {
+		const obj = {
+			a: 1,
+			b: null,
+			c: undefined,
+			d: []
+		};
+
+		const filteredObj = filterObjectValues(
+			obj,
+			value => value !== null
+		);
+
+		expect( filteredObj ).toEqual( {
+			a: 1,
+			c: undefined,
+			d: []
+		} );
+	} );
+} );

--- a/tests/utils/mapObjectValues.test.ts
+++ b/tests/utils/mapObjectValues.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mapObjectValues } from '@/utils/mapObjectValues';
+
+describe( 'mapObjectValues', () => {
+	it( 'should map object values using the provided mapper function', () => {
+		const obj = {
+			a: 1,
+			b: 2
+		};
+
+		const mappedObj = mapObjectValues( obj, value => value * 2 );
+
+		expect( mappedObj ).toEqual( { a: 2, b: 4 } );
+	} );
+} );

--- a/tests/utils/preloadResource.test.ts
+++ b/tests/utils/preloadResource.test.ts
@@ -22,7 +22,7 @@ describe( 'preloadResource', () => {
 		const linkElement = document.head.querySelector( `link[href="${ CDN_MOCK_STYLESHEET_URL }"][rel="preload"]` );
 
 		expect( linkElement ).toBeTruthy();
-		expect( linkElement!.getAttribute( 'injected-by' ) ).toBe( 'ckeditor-integration' );
+		expect( linkElement!.getAttribute( 'data-injected-by' ) ).toBe( 'ckeditor-integration' );
 		expect( linkElement!.getAttribute( 'as' ) ).toBe( 'style' );
 		expect( linkElement!.getAttribute( 'href' ) ).toBe( CDN_MOCK_STYLESHEET_URL );
 	} );

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"src/**/*.ts",
+		"tests/**/*.ts"
+	]
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

The API interface of the loadCKEditorCloud method has been simplified, and the ability to specify the CKBox theme has been added.

---

### What changed?

#### Added shorter ways to load plugins

```tsx
const { CKEditor, loadedPlugins } = await loadCKEditorCloud( {
  version: '43.0.0',
  plugins: {
    // New one, example: local UMD plugins
    Plugin1: async () => import( './your-local-import.umd.js' ),

    // New one, example: local external imports
    // Additional bundler configuration must be used, like this one: 
    // https://github.com/crcong/vite-plugin-externals
    Plugin11: async () => import( './your-local-import' ) as unknown as Promise<Your_Type>,
   
    // New one, example: CDN 3rd party
    Plugin2: [
      'https://cdn.example.com/plugin2.js',
      'https://cdn.example.com/plugin2.css'
    ],

    // Old one, verbose for more advanced plugins. It's still available.
    Plugin3: {
      scripts: [ 'https://cdn.example.com/plugin3.js' ],
      stylesheets: [ 'https://cdn.example.com/plugin3.css' ],
      // Optional, if it's not passed then the type of `Plugin3` will be picked from `Window`
      getExportedEntries: () => ( window as any ).Plugin3
    }
  }
} );
```

Automatic type inferring by Window key name:

```tsx
declare global {
  interface Window {
    Plugin2?: { stuff: true }
  };
};

const { CKEditor, loadedPlugins } = await loadCKEditorCloud( {
  version: '43.0.0',
  plugins: {
    Plugin2: [ 'https://cdn.example.com/plugin2.js' ]
  }
} );

expectTypeOf( loadedPlugins.Plugin2 ).toEqualTypeOf< { stuff: true }>();
```

#### Added `ckbox` theme config attribute

`CKBox` can be used without providing any `theme`, but it looks better when it is provided. If nothing specified, `lark` is used. 

```tsx
const { CKEditor } = await loadCKEditorCloud( {
  version: '43.0.0',
  ckbox: {
     version: '2.5.0',
     theme: 'lark', // or null
  }
} );
```

### Additional information

1. Renamed `injected-by` -> `data-injected-by`
3. Renamed `CKPlugins` to `loadedPlugins`