### PR TITLE
Rename `confirmPluginReady` to `checkPluginLoaded`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint --quiet \"**/*.{ts,tsx}\"",
     "test": "vitest run --coverage",
     "test:watch": "vitest --ui --watch",
-    "test:check:types": "tsc --noEmit -p ./tsconfig.test.json",
+    "test:check:types": "tsc --noEmit -p ./tests/tsconfig.json",
     "changelog": "node ./scripts/changelog.js",
     "release:prepare-packages": "node ./scripts/preparepackages.js",
     "release:publish-packages": "node ./scripts/publishpackages.js"

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -65,7 +65,7 @@ export function createCKCdnBaseBundlePack(
 		stylesheets: urls.stylesheets,
 
 		// Pick the exported global variables from the window object.
-		confirmPluginReady: async () =>
+		checkPluginLoaded: async () =>
 			waitForWindowEntry( [ 'CKEDITOR' ] )
 	};
 }

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -66,7 +66,7 @@ export function createCKCdnPremiumBundlePack(
 		stylesheets: urls.stylesheets,
 
 		// Pick the exported global variables from the window object.
-		confirmPluginReady: async () =>
+		checkPluginLoaded: async () =>
 			waitForWindowEntry( [ 'CKEDITOR_PREMIUM_FEATURES' ] )
 	};
 }

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -45,7 +45,7 @@ export function createCKBoxBundlePack(
 		},
 
 		// Pick the exported global variables from the window object.
-		confirmPluginReady: async () =>
+		checkPluginLoaded: async () =>
 			waitForWindowEntry( [ 'CKBox' ] )
 	};
 }

--- a/src/cdn/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/combineCKCdnBundlesPacks.ts
@@ -59,13 +59,13 @@ export function combineCKCdnBundlesPacks<P extends CKCdnBundlesPacks>( packs: P 
 		);
 
 	// Get exported entries from all packs.
-	const confirmPluginReady = async () => {
+	const checkPluginLoaded = async () => {
 		// Use Object.create() to create an object without a prototype to avoid prototype pollution.
 		const exportedGlobalVariables: Record<string, unknown> = Object.create( null );
 
 		// It can be done sequentially because scripts *should* be loaded at this point and the whole execution should be quite fast.
 		for ( const [ name, pack ] of Object.entries( normalizedPacks ) ) {
-			exportedGlobalVariables[ name ] = await pack?.confirmPluginReady?.();
+			exportedGlobalVariables[ name ] = await pack?.checkPluginLoaded?.();
 		}
 
 		return exportedGlobalVariables as any;
@@ -73,7 +73,7 @@ export function combineCKCdnBundlesPacks<P extends CKCdnBundlesPacks>( packs: P 
 
 	return {
 		...mergedPacks,
-		confirmPluginReady
+		checkPluginLoaded
 	};
 }
 

--- a/src/cdn/loadCKCdnResourcesPack.ts
+++ b/src/cdn/loadCKCdnResourcesPack.ts
@@ -22,7 +22,7 @@ import { uniq } from '../utils/uniq';
  * 	scripts: [
  * 		'https://cdn.ckeditor.com/ckeditor5/30.0.0/classic/ckeditor.js'
  * 	],
- * 	confirmPluginReady: () => ( window as any ).ClassicEditor
+ * 	checkPluginLoaded: () => ( window as any ).ClassicEditor
  * } );
  * ```
  */
@@ -31,7 +31,7 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 		scripts = [],
 		stylesheets = [],
 		preload,
-		confirmPluginReady
+		checkPluginLoaded
 	} = normalizeCKCdnResourcesPack( pack );
 
 	// If preload is not defined, use all stylesheets and scripts as preload resources.
@@ -60,7 +60,7 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 	}
 
 	// Wait for execution all injected scripts.
-	return confirmPluginReady?.();
+	return checkPluginLoaded?.();
 }
 
 /**
@@ -86,7 +86,7 @@ export function normalizeCKCdnResourcesPack<R = any>( pack: CKCdnResourcesPack<R
 	// Check if it is a local import function, if so, convert it to the advanced format.
 	if ( typeof pack === 'function' ) {
 		return {
-			confirmPluginReady: pack
+			checkPluginLoaded: pack
 		};
 	}
 
@@ -134,7 +134,7 @@ type CKCdnResourcesBasicUrlsPack = Array<string>;
  * 	scripts: [
  * 		'https://cdn.ckeditor.com/ckeditor5/30.0.0/classic/ckeditor.js'
  * 	],
- * 	confirmPluginReady: () => ( window as any ).ClassicEditor
+ * 	checkPluginLoaded: () => ( window as any ).ClassicEditor
  * };
  * ```
  */
@@ -158,7 +158,7 @@ export type CKCdnResourcesAdvancedPack<R> = {
 	/**
 	 * Get JS object with global variables exported by scripts.
 	 */
-	confirmPluginReady?: () => Awaitable<R>;
+	checkPluginLoaded?: () => Awaitable<R>;
 };
 
 /**

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -64,13 +64,13 @@ import {
  * 			stylesheets: [ 'https://cdn.example.com/plugin3.css' ],
  *
  * 			// Optional, if it's not passed then the type of `Plugin3` will be picked from `Window`
- * 			confirmPluginReady: () => ( window as any ).Plugin3
+ * 			checkPluginLoaded: () => ( window as any ).Plugin3
  * 		}
  * 	}
  * } );
  * ```
  *
- * Type of plugins can be inferred if `confirmPluginReady` is not provided: In this case,
+ * Type of plugins can be inferred if `checkPluginLoaded` is not provided: In this case,
  * the type of the plugin will be picked from the global window scope.
  */
 export function loadCKEditorCloud<Plugins extends CKCdnBundlesPacks>(

--- a/src/cdn/plugins/combineCdnPluginsPacks.ts
+++ b/src/cdn/plugins/combineCdnPluginsPacks.ts
@@ -51,7 +51,7 @@ export function combineCdnPluginsPacks<Plugins extends CKCdnBundlesPacks>(
 
 		return {
 			// Provide default window accessor object if the plugin pack does not define it.
-			confirmPluginReady: async (): Promise<unknown> =>
+			checkPluginLoaded: async (): Promise<unknown> =>
 				waitForWindowEntry( [ pluginName as any ] ),
 
 			// Transform the plugin pack to a normalized advanced pack.
@@ -67,7 +67,7 @@ export function combineCdnPluginsPacks<Plugins extends CKCdnBundlesPacks>(
 
 /**
  * A combined pack of plugins. It picks the type of the plugin from the global scope if
- * `CKCdnCombinedBundlePack` does not define it in the `confirmPluginReady` method.
+ * `CKCdnCombinedBundlePack` does not define it in the `checkPluginLoaded` method.
  */
 export type CombinedPluginsPackWithFallbackScope<P extends CKCdnBundlesPacks> = CKCdnResourcesAdvancedPack<{
 	[ K in keyof P ]: FallbackIfUnknown<

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -32,7 +32,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 			'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.css'
 		] );
 
-		expect( pack.confirmPluginReady ).toBeInstanceOf( Function );
+		expect( pack.checkPluginLoaded ).toBeInstanceOf( Function );
 	} );
 
 	it( 'should not load any language if not provided', () => {
@@ -41,7 +41,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 		} );
 
 		expect( pack ).to.toMatchObject( {
-			confirmPluginReady: expect.any( Function ),
+			checkPluginLoaded: expect.any( Function ),
 			stylesheets: [
 				'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.css'
 			],

--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -25,7 +25,7 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css'
 		] );
 
-		expect( pack.confirmPluginReady ).toBeInstanceOf( Function );
+		expect( pack.checkPluginLoaded ).toBeInstanceOf( Function );
 	} );
 
 	it( 'should not load any language if not provided', () => {
@@ -34,7 +34,7 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 		} );
 
 		expect( pack ).to.toMatchObject( {
-			confirmPluginReady: expect.any( Function ),
+			checkPluginLoaded: expect.any( Function ),
 			stylesheets: [
 				'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css'
 			],

--- a/tests/cdn/ckbox/createCKBoxBundlePack.test.ts
+++ b/tests/cdn/ckbox/createCKBoxBundlePack.test.ts
@@ -19,7 +19,7 @@ describe( 'createCKBoxBundlePack', () => {
 			stylesheets: [
 				'https://cdn.ckbox.io/ckbox/2.5.1/styles/themes/lark.css'
 			],
-			confirmPluginReady: expect.any( Function )
+			checkPluginLoaded: expect.any( Function )
 		} );
 	} );
 } );

--- a/tests/cdn/combineCKCdnBundlesPacks.test.ts
+++ b/tests/cdn/combineCKCdnBundlesPacks.test.ts
@@ -12,14 +12,14 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			preload: [ 'preload1' ],
 			scripts: [ 'script1' ],
 			stylesheets: [ 'stylesheet1' ],
-			confirmPluginReady: async () => ( { exported1: 'value1' } )
+			checkPluginLoaded: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			preload: [ 'preload2' ],
 			scripts: [ 'script2' ],
 			stylesheets: [ 'stylesheet2' ],
-			confirmPluginReady: async () => ( { exported2: 'value2' } )
+			checkPluginLoaded: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -33,7 +33,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1', 'stylesheet2' ]
 		} );
 
-		const exportedEntries = await combinedPack.confirmPluginReady!();
+		const exportedEntries = await combinedPack.checkPluginLoaded!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -46,7 +46,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			preload: [ 'preload1' ],
 			scripts: [ 'script1' ],
 			stylesheets: [ 'stylesheet1' ],
-			confirmPluginReady: async () => ( { exported1: 'value1' } )
+			checkPluginLoaded: async () => ( { exported1: 'value1' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -60,7 +60,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1' ]
 		} );
 
-		const exportedEntries = await combinedPack.confirmPluginReady!();
+		const exportedEntries = await combinedPack.checkPluginLoaded!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -77,7 +77,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: []
 		} );
 
-		const exportedEntries = await combinedPack.confirmPluginReady!();
+		const exportedEntries = await combinedPack.checkPluginLoaded!();
 
 		expect( exportedEntries ).toEqual( {} );
 	} );
@@ -86,13 +86,13 @@ describe( 'combineCKCdnBundlesPacks', () => {
 		const pack1 = {
 			preload: [ 'preload1' ],
 			stylesheets: [ 'stylesheet1' ],
-			confirmPluginReady: async () => ( { exported1: 'value1' } )
+			checkPluginLoaded: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			preload: [ 'preload2' ],
 			stylesheets: [ 'stylesheet2' ],
-			confirmPluginReady: async () => ( { exported2: 'value2' } )
+			checkPluginLoaded: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -105,7 +105,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1', 'stylesheet2' ]
 		} );
 
-		const exportedEntries = await combinedPack.confirmPluginReady!();
+		const exportedEntries = await combinedPack.checkPluginLoaded!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -117,13 +117,13 @@ describe( 'combineCKCdnBundlesPacks', () => {
 		const pack1 = {
 			preload: [ 'preload1' ],
 			scripts: [ 'script1' ],
-			confirmPluginReady: async () => ( { exported1: 'value1' } )
+			checkPluginLoaded: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			preload: [ 'preload2' ],
 			scripts: [ 'script2' ],
-			confirmPluginReady: async () => ( { exported2: 'value2' } )
+			checkPluginLoaded: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -136,7 +136,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			scripts: [ 'script1', 'script2' ]
 		} );
 
-		const exportedEntries = await combinedPack.confirmPluginReady!();
+		const exportedEntries = await combinedPack.checkPluginLoaded!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },
@@ -148,13 +148,13 @@ describe( 'combineCKCdnBundlesPacks', () => {
 		const pack1 = {
 			scripts: [ 'script1' ],
 			stylesheets: [ 'stylesheet1' ],
-			confirmPluginReady: async () => ( { exported1: 'value1' } )
+			checkPluginLoaded: async () => ( { exported1: 'value1' } )
 		};
 
 		const pack2 = {
 			scripts: [ 'script2' ],
 			stylesheets: [ 'stylesheet2' ],
-			confirmPluginReady: async () => ( { exported2: 'value2' } )
+			checkPluginLoaded: async () => ( { exported2: 'value2' } )
 		};
 
 		const combinedPack = combineCKCdnBundlesPacks( {
@@ -167,7 +167,7 @@ describe( 'combineCKCdnBundlesPacks', () => {
 			stylesheets: [ 'stylesheet1', 'stylesheet2' ]
 		} );
 
-		const exportedEntries = await combinedPack.confirmPluginReady!();
+		const exportedEntries = await combinedPack.checkPluginLoaded!();
 
 		expect( exportedEntries ).toEqual( {
 			Pack1: { exported1: 'value1' },

--- a/tests/cdn/loadCKCdnResourcesPack.test.ts
+++ b/tests/cdn/loadCKCdnResourcesPack.test.ts
@@ -29,14 +29,14 @@ describe( 'loadCKCdnResourcesPack', () => {
 	} );
 
 	it( 'should return the exported global variables', async () => {
-		const confirmPluginReady = vitest.fn( () => ( {
+		const checkPluginLoaded = vitest.fn( () => ( {
 			ClassicEditor: {
 				version: '30.0.0'
 			}
 		} ) );
 
 		const result = await loadCKCdnResourcesPack( {
-			confirmPluginReady
+			checkPluginLoaded
 		} );
 
 		expect( result ).toEqual( {
@@ -45,7 +45,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 			}
 		} );
 
-		expect( confirmPluginReady ).toHaveBeenCalled();
+		expect( checkPluginLoaded ).toHaveBeenCalled();
 	} );
 
 	it( 'should not inject any script if the pack does not contain any', async () => {
@@ -56,7 +56,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 		};
 
 		const loaded = await loadCKCdnResourcesPack( {
-			confirmPluginReady: () => result
+			checkPluginLoaded: () => result
 		} );
 
 		expect( result ).toEqual( loaded );
@@ -65,7 +65,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 	it( 'should inject the script if the pack contains one', async () => {
 		const loaded = await loadCKCdnResourcesPack( {
 			scripts: [ CDN_MOCK_SCRIPT_URL ],
-			confirmPluginReady: () => window.CKEDITOR!
+			checkPluginLoaded: () => window.CKEDITOR!
 		} );
 
 		expect( loaded ).toBeDefined();
@@ -94,7 +94,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 	it( 'should use preload property instead default one if passed', async () => {
 		const loaded = await loadCKCdnResourcesPack( {
 			preload: [ CDN_MOCK_SCRIPT_URL ],
-			confirmPluginReady: () => ( {
+			checkPluginLoaded: () => ( {
 				result: 2
 			} )
 		} );
@@ -107,7 +107,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 		const loaded = await loadCKCdnResourcesPack( {
 			scripts: [ CDN_MOCK_SCRIPT_URL ],
 			stylesheets: [ CDN_MOCK_STYLESHEET_URL ],
-			confirmPluginReady: () => ( {
+			checkPluginLoaded: () => ( {
 				result: 2
 			} )
 		} );
@@ -124,7 +124,7 @@ describe( 'loadCKCdnResourcesPack', () => {
 
 		await loadCKCdnResourcesPack( {
 			scripts: [ customFunction ],
-			confirmPluginReady: () => ( {
+			checkPluginLoaded: () => ( {
 				result: 2
 			} )
 		} );

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -77,7 +77,7 @@ describe( 'loadCKEditorCloud', () => {
 	} );
 
 	describe( 'plugins', () => {
-		it( 'should properly infer type of global variable if confirmPluginReady is not provided', async () => {
+		it( 'should properly infer type of global variable if checkPluginLoaded is not provided', async () => {
 			const { loadedPlugins } = await loadCKEditorCloud( {
 				version: '43.0.0',
 				plugins: {
@@ -88,13 +88,13 @@ describe( 'loadCKEditorCloud', () => {
 			expectTypeOf( loadedPlugins.FakePlugin ).toEqualTypeOf<FakePlugin>();
 		} );
 
-		it( 'should properly infer type of global variable if confirmPluginReady is provided', async () => {
+		it( 'should properly infer type of global variable if checkPluginLoaded is provided', async () => {
 			const { loadedPlugins } = await loadCKEditorCloud( {
 				version: '43.0.0',
 				plugins: {
 					FakePlugin: {
 						scripts: [ createCKBoxCdnUrl( 'ckbox', 'ckbox.js', '2.5.1' ) ],
-						confirmPluginReady: () => window.FakePlugin2
+						checkPluginLoaded: () => window.FakePlugin2
 					}
 				}
 			} );

--- a/tests/cdn/plugins/combineCKPluginsPacks.test.ts
+++ b/tests/cdn/plugins/combineCKPluginsPacks.test.ts
@@ -19,7 +19,7 @@ describe( 'combineCdnPluginsPacks', () => {
 		delete window.ScreenReader;
 	} );
 
-	it( 'should define default `confirmPluginReady` if not present', async () => {
+	it( 'should define default `checkPluginLoaded` if not present', async () => {
 		const combinedPack = combineCdnPluginsPacks( {
 			ScreenReader: [ 'https://example.org/screen-reader.js' ],
 			AccessibilityChecker: undefined
@@ -29,15 +29,15 @@ describe( 'combineCdnPluginsPacks', () => {
 			scripts: [ 'https://example.org/screen-reader.js' ],
 			preload: [],
 			stylesheets: [],
-			confirmPluginReady: expect.any( Function )
+			checkPluginLoaded: expect.any( Function )
 		} );
 
-		expectTypeOf( combinedPack.confirmPluginReady!()! ).toEqualTypeOf<Awaitable<{
+		expectTypeOf( combinedPack.checkPluginLoaded!()! ).toEqualTypeOf<Awaitable<{
 			ScreenReader: ScreenReader | undefined;
 			AccessibilityChecker: never;
 		}>>();
 
-		await expect( combinedPack.confirmPluginReady!() ).resolves.toEqual( {
+		await expect( combinedPack.checkPluginLoaded!() ).resolves.toEqual( {
 			ScreenReader: {
 				test: 123
 			}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"include": [
-		"src/**/*.ts",
-		"tests/**/*.ts"
-	]
-}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Rename `confirmPluginReady` to `checkPluginLoaded`.

---

### Additional information

Based on this comment:
https://github.com/ckeditor/ckeditor5-integrations-common/pull/15#issuecomment-2311137475