### PR TITLE
Add missing export for `CKCdnResourcesPack`

### DIFF
--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -6,11 +6,7 @@
 import { createCKCdnBaseBundlePack } from './ck/createCKCdnBaseBundlePack';
 import { createCKCdnPremiumBundlePack } from './ck/createCKCdnPremiumBundlePack';
 
-import {
-	combineCKCdnBundlesPacks,
-	type CKCdnBundlesPacks
-} from './combineCKCdnBundlesPacks';
-
+import { combineCKCdnBundlesPacks } from './combineCKCdnBundlesPacks';
 import {
 	createCKBoxBundlePack,
 	type CKBoxCdnBundlePackConfig
@@ -24,7 +20,8 @@ import {
 
 import {
 	combineCdnPluginsPacks,
-	type CombinedPluginsPackWithFallbackScope
+	type CombinedPluginsPackWithFallbackScope,
+	type CdnPluginsPacks
 } from './plugins/combineCdnPluginsPacks';
 
 /**
@@ -73,7 +70,7 @@ import {
  * Type of plugins can be inferred if `checkPluginLoaded` is not provided: In this case,
  * the type of the plugin will be picked from the global window scope.
  */
-export function loadCKEditorCloud<Plugins extends CKCdnBundlesPacks>(
+export function loadCKEditorCloud<Plugins extends CdnPluginsPacks>(
 	config: CKEditorCloudConfig<Plugins>
 ): Promise<CKEditorCloudResult<Plugins>> {
 	const {
@@ -107,7 +104,7 @@ export function loadCKEditorCloud<Plugins extends CKCdnBundlesPacks>(
 /**
  * The result of the resolved bundles from CKEditor Cloud Services.
  */
-export type CKEditorCloudResult<Plugins extends CKCdnBundlesPacks = any> = {
+export type CKEditorCloudResult<Plugins extends CdnPluginsPacks = any> = {
 
 	/**
 	 * The base CKEditor bundle exports.
@@ -135,7 +132,7 @@ export type CKEditorCloudResult<Plugins extends CKCdnBundlesPacks = any> = {
 /**
  * The configuration of the `useCKEditorCloud` hook.
  */
-export type CKEditorCloudConfig<Plugins extends CKCdnBundlesPacks = CKCdnBundlesPacks> = {
+export type CKEditorCloudConfig<Plugins extends CdnPluginsPacks = CdnPluginsPacks> = {
 
 	/**
 	 * The version of CKEditor Cloud Services to use.

--- a/src/cdn/plugins/combineCdnPluginsPacks.ts
+++ b/src/cdn/plugins/combineCdnPluginsPacks.ts
@@ -39,7 +39,7 @@ import {
  * In example above, `ScreenReader` and `AccessibilityChecker` are the plugins names and
  * the type of the exported entries will be picked from the global (Window) scope.
  */
-export function combineCdnPluginsPacks<Plugins extends CKCdnBundlesPacks>(
+export function combineCdnPluginsPacks<Plugins extends CdnPluginsPacks>(
 	pluginsPacks: Plugins
 ): CombinedPluginsPackWithFallbackScope<Plugins> {
 	const normalizedPluginsPacks = mapObjectValues( pluginsPacks, ( pluginPack, pluginName ) => {
@@ -66,10 +66,15 @@ export function combineCdnPluginsPacks<Plugins extends CKCdnBundlesPacks>(
 }
 
 /**
+ * A map of CKEditor plugins packs.
+ */
+export type CdnPluginsPacks = CKCdnBundlesPacks;
+
+/**
  * A combined pack of plugins. It picks the type of the plugin from the global scope if
  * `CKCdnCombinedBundlePack` does not define it in the `checkPluginLoaded` method.
  */
-export type CombinedPluginsPackWithFallbackScope<P extends CKCdnBundlesPacks> = CKCdnResourcesAdvancedPack<{
+export type CombinedPluginsPackWithFallbackScope<P extends CdnPluginsPacks> = CKCdnResourcesAdvancedPack<{
 	[ K in keyof P ]: FallbackIfUnknown<
 		InferCKCdnResourcesPackExportsType<P[K]>,
 		K extends keyof Window ? Window[ K ] : unknown

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,3 +41,7 @@ export {
 	type CKEditorCloudConfig,
 	type CKEditorCloudResult
 } from './cdn/loadCKEditorCloud';
+
+export type {
+	CdnPluginsPacks
+} from './cdn/plugins/combineCdnPluginsPacks';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Export missing `CdnPluginsPacks` typing, which is used in integrations. 

---

### Additional information

It was accidentally removed in https://github.com/ckeditor/ckeditor5-integrations-common/pull/15, but should be exported as it is used in integrations logic. 
