### PR TITLE
Inject stylesheets at the start of the head instead of the end. 

### DIFF
--- a/src/cdn/loadCKCdnResourcesPack.ts
+++ b/src/cdn/loadCKCdnResourcesPack.ts
@@ -45,11 +45,11 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 	// Preload resources specified in the pack.
 	preload.forEach( preloadResource );
 
-	// Load stylesheet tags before scripts to avoid flash of unstyled content.
+	// Load stylesheet tags before scripts to avoid a flash of unstyled content.
 	await Promise.all(
 		uniq( stylesheets ).map( href => injectStylesheet( {
 			href,
-			headPlacement: 'start'
+			placementInHead: 'start'
 		} ) )
 	);
 

--- a/src/cdn/loadCKCdnResourcesPack.ts
+++ b/src/cdn/loadCKCdnResourcesPack.ts
@@ -47,7 +47,10 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 
 	// Load stylesheet tags before scripts to avoid flash of unstyled content.
 	await Promise.all(
-		uniq( stylesheets ).map( injectStylesheet )
+		uniq( stylesheets ).map( href => injectStylesheet( {
+			href,
+			headPlacement: 'start'
+		} ) )
 	);
 
 	// Load script tags.

--- a/src/utils/injectStylesheet.ts
+++ b/src/utils/injectStylesheet.ts
@@ -13,10 +13,10 @@ export const INJECTED_STYLESHEETS = new Map<string, Promise<void>>();
  * Injects a stylesheet into the document.
  *
  * @param props.href The URL of the stylesheet to be injected.
- * @param props.headPlacement The placement of the stylesheet in the head.
+ * @param props.placementInHead The placement of the stylesheet in the head.
  * @returns A promise that resolves when the stylesheet is loaded.
  */
-export function injectStylesheet( { href, headPlacement = 'start' }: InjectStylesheetProps ): Promise<void> {
+export function injectStylesheet( { href, placementInHead = 'start' }: InjectStylesheetProps ): Promise<void> {
 	// Return the promise if the stylesheet is already injected by this function.
 	if ( INJECTED_STYLESHEETS.has( href ) ) {
 		return INJECTED_STYLESHEETS.get( href )!;
@@ -33,22 +33,22 @@ export function injectStylesheet( { href, headPlacement = 'start' }: InjectStyle
 
 	// Append the link tag to the head.
 	const appendLinkTagToHead = ( link: HTMLLinkElement ) => {
-		const previouslyInsertedStylesheets = Array.from(
+		const previouslyInjectedStylesheets = Array.from(
 			document.head.querySelectorAll( 'link[data-injected-by="ckeditor-integration"][rel="stylesheet"]' )
 		);
 
-		switch ( headPlacement ) {
+		switch ( placementInHead ) {
 			// It'll append styles *before* the stylesheets that are already present in the head
 			// but after the ones that are injected by this function.
 			case 'start':
-				if ( previouslyInsertedStylesheets.length ) {
-					previouslyInsertedStylesheets.slice( -1 )[ 0 ].after( link );
+				if ( previouslyInjectedStylesheets.length ) {
+					previouslyInjectedStylesheets.slice( -1 )[ 0 ].after( link );
 				} else {
 					document.head.insertBefore( link, document.head.firstChild );
 				}
 				break;
 
-			// It'll append styles *after* the stylesheets that are already present in the head.
+			// It'll append styles *after* the stylesheets already in the head.
 			case 'end':
 				document.head.appendChild( link );
 				break;
@@ -105,5 +105,5 @@ type InjectStylesheetProps = {
 	 * The placement of the stylesheet in the head. It can be either at the start or at the end
 	 * of the head. Default is 'start' because it allows user to override the styles easily.
 	 */
-	headPlacement?: 'start' | 'end';
+	placementInHead?: 'start' | 'end';
 };

--- a/tests/cdn/loadCKCdnResourcesPack.test.ts
+++ b/tests/cdn/loadCKCdnResourcesPack.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, vi, expect, vitest, beforeEach, afterEach } from 'vitest';
 
 import { loadCKCdnResourcesPack } from '@/cdn/loadCKCdnResourcesPack';
+import { createCKCdnUrl } from '@/src/cdn/ck/createCKCdnUrl';
 import {
 	queryScript,
 	queryStylesheet,
@@ -130,5 +131,28 @@ describe( 'loadCKCdnResourcesPack', () => {
 		} );
 
 		expect( customFunction ).toHaveBeenCalled();
+	} );
+
+	it( 'should inject the stylesheet at the start of the head', async () => {
+		// Manually inject the stylesheet into the document.
+		const stylesheet1 = document.createElement( 'link' );
+		stylesheet1.rel = 'stylesheet';
+		stylesheet1.href = createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.0' );
+		document.head.appendChild( stylesheet1 );
+
+		// Inject the stylesheet using the loadCKCdnResourcesPack function.
+		await loadCKCdnResourcesPack( {
+			stylesheets: [ CDN_MOCK_STYLESHEET_URL ]
+		} );
+
+		// Verify that the stylesheet are injected at the start of the head.
+		const injectedStylesheets = [ ...document.head.querySelectorAll( 'link[rel="stylesheet"]' ) ].map(
+			link => link.getAttribute( 'href' )!
+		);
+
+		expect( injectedStylesheets ).toEqual( [
+			CDN_MOCK_STYLESHEET_URL,
+			createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.0' )
+		] );
 	} );
 } );

--- a/tests/utils/injectStylesheet.test.ts
+++ b/tests/utils/injectStylesheet.test.ts
@@ -80,7 +80,7 @@ describe( 'injectStylesheet', () => {
 		const appendChildSpy = vi.spyOn( document.head, 'appendChild' );
 
 		// Call the injectStylesheet function with headPlacement = 'end'
-		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL, headPlacement: 'end' } );
+		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL, placementInHead: 'end' } );
 
 		// Verify that the stylesheet element is created and appended to the document
 		expect( createElementSpy ).toHaveBeenCalledWith( 'link' );
@@ -96,7 +96,7 @@ describe( 'injectStylesheet', () => {
 		const insertBeforeSpy = vi.spyOn( document.head, 'insertBefore' );
 
 		// Call the injectStylesheet function with headPlacement = 'start'
-		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL, headPlacement: 'start' } );
+		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL, placementInHead: 'start' } );
 
 		// Verify that the stylesheet element is created and appended to the document
 		expect( createElementSpy ).toHaveBeenCalledWith( 'link' );
@@ -116,12 +116,12 @@ describe( 'injectStylesheet', () => {
 		// Call the injectStylesheet function with headPlacement = 'start'
 		await injectStylesheet( {
 			href: CDN_MOCK_STYLESHEET_URL,
-			headPlacement: 'start'
+			placementInHead: 'start'
 		} );
 
 		await injectStylesheet( {
 			href: createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.1' ),
-			headPlacement: 'start'
+			placementInHead: 'start'
 		} );
 
 		// Verify that the stylesheet is injected after the previously injected stylesheet

--- a/tests/utils/injectStylesheet.test.ts
+++ b/tests/utils/injectStylesheet.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CDN_MOCK_STYLESHEET_URL, removeCkCdnLinks } from 'tests/_utils/ckCdnMocks';
 import { injectStylesheet } from '@/utils/injectStylesheet';
+import { createCKCdnUrl } from '@/src/cdn/ck/createCKCdnUrl';
 
 describe( 'injectStylesheet', () => {
 	beforeEach( () => {
@@ -23,14 +24,18 @@ describe( 'injectStylesheet', () => {
 	it( 'should inject a stylesheet into the document', async () => {
 		// Mock the document and stylesheet element
 		const createElementSpy = vi.spyOn( document, 'createElement' );
-		const appendChildSpy = vi.spyOn( document.head, 'appendChild' );
+		const insertBeforeSpy = vi.spyOn( document.head, 'insertBefore' );
 
 		// Call the injectStylesheet function
-		const promise = injectStylesheet( CDN_MOCK_STYLESHEET_URL );
+		const firstHeadChild = document.head.firstChild;
+		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL } );
 
 		// Verify that the stylesheet element is created and appended to the document
 		expect( createElementSpy ).toHaveBeenCalledWith( 'link' );
-		expect( appendChildSpy ).toHaveBeenCalledWith( expect.any( HTMLLinkElement ) );
+		expect( insertBeforeSpy ).toHaveBeenCalledWith(
+			expect.any( HTMLLinkElement ),
+			firstHeadChild
+		);
 
 		// Wait for the promise to resolve
 		await expect( promise ).resolves.toBeUndefined();
@@ -38,8 +43,8 @@ describe( 'injectStylesheet', () => {
 
 	it( 'should return the same promise if the stylesheet is already injected', async () => {
 		// Call the injectStylesheet function twice with the same source
-		const promise1 = injectStylesheet( CDN_MOCK_STYLESHEET_URL );
-		const promise2 = injectStylesheet( CDN_MOCK_STYLESHEET_URL );
+		const promise1 = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL } );
+		const promise2 = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL } );
 
 		// Verify that the promises are the same
 		expect( promise1 ).toBe( promise2 );
@@ -58,7 +63,7 @@ describe( 'injectStylesheet', () => {
 		document.head.appendChild( stylesheet );
 
 		// Call the injectStylesheet function
-		const promise = injectStylesheet( CDN_MOCK_STYLESHEET_URL );
+		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL } );
 
 		// Wait for the promise to resolve
 		await expect( promise ).resolves.toBeUndefined();
@@ -67,5 +72,67 @@ describe( 'injectStylesheet', () => {
 		expect( console.warn ).toHaveBeenCalledWith(
 			`Stylesheet with "${ CDN_MOCK_STYLESHEET_URL }" href is already present in DOM!`
 		);
+	} );
+
+	it( 'should inject the stylesheet at the end of the head if headPlacement = \'end\'', async () => {
+		// Mock the document and stylesheet element
+		const createElementSpy = vi.spyOn( document, 'createElement' );
+		const appendChildSpy = vi.spyOn( document.head, 'appendChild' );
+
+		// Call the injectStylesheet function with headPlacement = 'end'
+		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL, headPlacement: 'end' } );
+
+		// Verify that the stylesheet element is created and appended to the document
+		expect( createElementSpy ).toHaveBeenCalledWith( 'link' );
+		expect( appendChildSpy ).toHaveBeenCalled();
+
+		// Wait for the promise to resolve
+		await expect( promise ).resolves.toBeUndefined();
+	} );
+
+	it( 'should inject the stylesheet at the start of the head if headPlacement = \'start\'', async () => {
+		// Mock the document and stylesheet element
+		const createElementSpy = vi.spyOn( document, 'createElement' );
+		const insertBeforeSpy = vi.spyOn( document.head, 'insertBefore' );
+
+		// Call the injectStylesheet function with headPlacement = 'start'
+		const promise = injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL, headPlacement: 'start' } );
+
+		// Verify that the stylesheet element is created and appended to the document
+		expect( createElementSpy ).toHaveBeenCalledWith( 'link' );
+		expect( insertBeforeSpy ).toHaveBeenCalled();
+
+		// Wait for the promise to resolve
+		await expect( promise ).resolves.toBeUndefined();
+	} );
+
+	it( 'should inject the stylesheet after previously injected stylesheets if headPlacement = \'start\'', async () => {
+		// Manually inject the stylesheet into the document.
+		const stylesheet1 = document.createElement( 'link' );
+		stylesheet1.rel = 'stylesheet';
+		stylesheet1.href = createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.0' );
+		document.head.appendChild( stylesheet1 );
+
+		// Call the injectStylesheet function with headPlacement = 'start'
+		await injectStylesheet( {
+			href: CDN_MOCK_STYLESHEET_URL,
+			headPlacement: 'start'
+		} );
+
+		await injectStylesheet( {
+			href: createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.1' ),
+			headPlacement: 'start'
+		} );
+
+		// Verify that the stylesheet is injected after the previously injected stylesheet
+		const injectedStylesheets = [ ...document.head.querySelectorAll( 'link[rel="stylesheet"]' ) ].map(
+			link => link.getAttribute( 'href' )!
+		);
+
+		expect( injectedStylesheets ).toEqual( [
+			CDN_MOCK_STYLESHEET_URL,
+			createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.1' ),
+			createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.0' )
+		] );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: CSS scripts are now injected at the beginning of the document head, allowing for easier overriding of editor styles. 