### PR TITLE
Ensure that preload link tags are injected before stylesheet link tags

### DIFF
--- a/src/utils/injectStylesheet.ts
+++ b/src/utils/injectStylesheet.ts
@@ -33,9 +33,9 @@ export function injectStylesheet( { href, placementInHead = 'start' }: InjectSty
 
 	// Append the link tag to the head.
 	const appendLinkTagToHead = ( link: HTMLLinkElement ) => {
-		// Prefer to inject styles after the stylesheets that are already present in the head.
-		// Do not specify `rel` attribute because we want to inject the stylesheet even after
-		// preload link tags.
+		// Inject styles after the stylesheets that are already present in the head.
+		// Do not specify the `rel` attribute because we want to inject the stylesheet even after
+		// preloading link tags.
 		const previouslyInjectedLinks = Array.from(
 			document.head.querySelectorAll( 'link[data-injected-by="ckeditor-integration"]' )
 		);

--- a/src/utils/injectStylesheet.ts
+++ b/src/utils/injectStylesheet.ts
@@ -33,16 +33,19 @@ export function injectStylesheet( { href, placementInHead = 'start' }: InjectSty
 
 	// Append the link tag to the head.
 	const appendLinkTagToHead = ( link: HTMLLinkElement ) => {
-		const previouslyInjectedStylesheets = Array.from(
-			document.head.querySelectorAll( 'link[data-injected-by="ckeditor-integration"][rel="stylesheet"]' )
+		// Prefer to inject styles after the stylesheets that are already present in the head.
+		// Do not specify `rel` attribute because we want to inject the stylesheet even after
+		// preload link tags.
+		const previouslyInjectedLinks = Array.from(
+			document.head.querySelectorAll( 'link[data-injected-by="ckeditor-integration"]' )
 		);
 
 		switch ( placementInHead ) {
 			// It'll append styles *before* the stylesheets that are already present in the head
 			// but after the ones that are injected by this function.
 			case 'start':
-				if ( previouslyInjectedStylesheets.length ) {
-					previouslyInjectedStylesheets.slice( -1 )[ 0 ].after( link );
+				if ( previouslyInjectedLinks.length ) {
+					previouslyInjectedLinks.slice( -1 )[ 0 ].after( link );
 				} else {
 					document.head.insertBefore( link, document.head.firstChild );
 				}

--- a/src/utils/preloadResource.ts
+++ b/src/utils/preloadResource.ts
@@ -21,7 +21,7 @@ export function preloadResource( url: string ): void {
 	link.as = detectTypeOfResource( url );
 	link.href = url;
 
-	document.head.appendChild( link );
+	document.head.insertBefore( link, document.head.firstChild );
 }
 
 /**

--- a/tests/cdn/loadCKCdnResourcesPack.test.ts
+++ b/tests/cdn/loadCKCdnResourcesPack.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, vi, expect, vitest, beforeEach, afterEach } from 'vitest';
 
 import { loadCKCdnResourcesPack } from '@/cdn/loadCKCdnResourcesPack';
-import { createCKCdnUrl } from '@/src/cdn/ck/createCKCdnUrl';
+import { createCKCdnUrl } from '@/cdn/ck/createCKCdnUrl';
 import {
 	queryScript,
 	queryStylesheet,

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -11,7 +11,7 @@ import {
 import { loadCKEditorCloud } from '@/cdn/loadCKEditorCloud';
 import { createCKBoxBundlePack } from '@/cdn/ckbox/createCKBoxCdnBundlePack';
 import { removeCkCdnLinks, removeCkCdnScripts } from 'tests/_utils/ckCdnMocks';
-import { createCKBoxCdnUrl } from '@/src/cdn/ckbox/createCKBoxCdnUrl';
+import { createCKBoxCdnUrl } from '@/cdn/ckbox/createCKBoxCdnUrl';
 
 describe( 'loadCKEditorCloud', () => {
 	beforeEach( () => {

--- a/tests/cdn/plugins/combineCKPluginsPacks.test.ts
+++ b/tests/cdn/plugins/combineCKPluginsPacks.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, expectTypeOf } from 'vitest';
 
-import type { Awaitable } from '@/src/types/Awaitable';
+import type { Awaitable } from '@/types/Awaitable';
 import { combineCdnPluginsPacks } from '@/cdn/plugins/combineCdnPluginsPacks';
 
 describe( 'combineCdnPluginsPacks', () => {

--- a/tests/utils/filterBlankObjectValues.test.ts
+++ b/tests/utils/filterBlankObjectValues.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { filterBlankObjectValues } from '@/src/utils/filterBlankObjectValues';
+import { filterBlankObjectValues } from '@/utils/filterBlankObjectValues';
 
 describe( 'filterBlankObjectValues', () => {
 	it( 'should filter object values that are empty', () => {

--- a/tests/utils/filterObjectValues.test.ts
+++ b/tests/utils/filterObjectValues.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { filterObjectValues } from '@/src/utils/filterObjectValues';
+import { filterObjectValues } from '@/utils/filterObjectValues';
 
 describe( 'filterObjectValues', () => {
 	it( 'should filter object values using the provided filter function', () => {

--- a/tests/utils/injectStylesheet.test.ts
+++ b/tests/utils/injectStylesheet.test.ts
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CDN_MOCK_STYLESHEET_URL, removeCkCdnLinks } from 'tests/_utils/ckCdnMocks';
 import { injectStylesheet } from '@/utils/injectStylesheet';
-import { preloadResource } from '@/src/utils/preloadResource';
-import { createCKCdnUrl } from '@/src/cdn/ck/createCKCdnUrl';
+import { preloadResource } from '@/utils/preloadResource';
+import { createCKCdnUrl } from '@/cdn/ck/createCKCdnUrl';
 
 describe( 'injectStylesheet', () => {
 	beforeEach( () => {

--- a/tests/utils/injectStylesheet.test.ts
+++ b/tests/utils/injectStylesheet.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CDN_MOCK_STYLESHEET_URL, removeCkCdnLinks } from 'tests/_utils/ckCdnMocks';
 import { injectStylesheet } from '@/utils/injectStylesheet';
+import { preloadResource } from '@/src/utils/preloadResource';
 import { createCKCdnUrl } from '@/src/cdn/ck/createCKCdnUrl';
 
 describe( 'injectStylesheet', () => {
@@ -133,6 +134,24 @@ describe( 'injectStylesheet', () => {
 			CDN_MOCK_STYLESHEET_URL,
 			createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.1' ),
 			createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', '42.0.0' )
+		] );
+	} );
+
+	it( 'should inject the stylesheet after preload tags', async () => {
+		preloadResource( CDN_MOCK_STYLESHEET_URL );
+
+		await injectStylesheet( {
+			href: CDN_MOCK_STYLESHEET_URL,
+			placementInHead: 'start'
+		} );
+
+		const injectedLinks = [ ...document.head.querySelectorAll( 'link[rel="stylesheet"], link[rel="preload"]' ) ].map(
+			link => [ link.getAttribute( 'rel' ), link.getAttribute( 'href' ) ]
+		);
+
+		expect( injectedLinks ).toEqual( [
+			[ 'preload', CDN_MOCK_STYLESHEET_URL ],
+			[ 'stylesheet', CDN_MOCK_STYLESHEET_URL ]
 		] );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Ensure that preload link tags are injected before stylesheet link tags.

---

### Additional information

This PR ensures that injected stylesheet tags are placed _after_ preload tags, just to make sure the browser properly queues preloading. 
