### PR TITLE
Changelog for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## [1.0.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.2.1...v1.0.0) (2024-09-03)
+## [1.0.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.2.1...v1.0.0) (2024-09-04)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### Features
 
 * The API has been stabilized and the package is now considered stable.
-* Adjust `README.md` to better describe the package and its purpose. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/pull/23/commits/7eac80561cf4d72ecc0eb50ebb7977ddfd440e10))
+* Adjust `README.md` to better describe the package and its purpose. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/7eac80561cf4d72ecc0eb50ebb7977ddfd440e10))
 * CSS scripts are now injected at the beginning of the document head, allowing for easier overriding of editor styles. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/cd61e7ce7baad29adefd275661c9ca7ef5006095))
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Features
 
 * The API has been stabilized and the package is now considered stable.
+* Adjust `README.md` to better describe the package and its purpose. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/pull/23/commits/7eac80561cf4d72ecc0eb50ebb7977ddfd440e10))
 * CSS scripts are now injected at the beginning of the document head, allowing for easier overriding of editor styles. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/cd61e7ce7baad29adefd275661c9ca7ef5006095))
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+## [1.0.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.2.1...v1.0.0) (2024-09-03)
+
+### Features
+
+* CSS scripts are now injected at the beginning of the document head, allowing for easier overriding of editor styles. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/cd61e7ce7baad29adefd275661c9ca7ef5006095))
+
+### Bug fixes
+
+* Ensure that preload link tags are injected before stylesheet link tags. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/d61b83e8ffede29debcc11c4be2798ad30d527e4))
+
+
 ## [0.2.1](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.2.0...v0.2.1) (2024-08-27)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@ Changelog
 
 ## [1.0.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v0.2.1...v1.0.0) (2024-09-04)
 
+We are happy to announce the first stable release of `@ckeditor/ckeditor5-integrations-common`, a package containing utility modules for integrating with CKEditor 5.
+
+Below, you can find changes compared to the latest non-stable release.
+
 ### Features
 
-* The API has been stabilized and the package is now considered stable.
-* Adjust `README.md` to better describe the package and its purpose. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/7eac80561cf4d72ecc0eb50ebb7977ddfd440e10))
 * CSS scripts are now injected at the beginning of the document head, allowing for easier overriding of editor styles. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/cd61e7ce7baad29adefd275661c9ca7ef5006095))
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Features
 
+* The API has been stabilized and the package is now considered stable.
 * CSS scripts are now injected at the beginning of the document head, allowing for easier overriding of editor styles. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/cd61e7ce7baad29adefd275661c9ca7ef5006095))
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5-integrations-common/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5-integrations-common?branch=master)
 ![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-integrations-common)
 
-Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) common integration utils.
+Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) common integration utils. This package contains a set of utilities that are shared between CKEditor 5 framework integrations such like:
+
+- [CKEditor 5 Vue integration](https://github.com/ckeditor/ckeditor5-vue)
+- [CKEditor 5 React integration](https://github.com/ckeditor/ckeditor5-react)
+- [CKEditor 5 Angular integration](https://github.com/ckeditor/ckeditor5-angular)
+
+The prime example of such shared utility might be the CKEditor 5 Cloud integration loader that is used by all integrations to dynamically load the editor from the CDN.
+
+It's highly recommended to not use this package directly in your application because it's intended to be used by through the integrations listed above. However, if you need to use it directly (because you are using framework that is not supported by the integrations), you can use it as a standalone package, but keep in mind that the API is designed to be used by the integrations and might not be user-friendly.
 
 ## Contributing
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Release `1.0.0` version with minor fixes in stylesheet injector order. 

---

Internal: Changelog for v1.0.0.

