### PR TITLE
Rename `languages` to `translations` config entry.

### DIFF
--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -22,7 +22,7 @@ import './globals.d';
  * const { Paragraph } = await loadCKCdnResourcesPack(
  * 	createCKCdnBaseBundlePack( {
  * 		version: '43.0.0',
- * 		languages: [ 'en', 'de' ]
+ * 		translations: [ 'en', 'de' ]
  * 	} )
  * );
  * ```
@@ -30,7 +30,7 @@ import './globals.d';
 export function createCKCdnBaseBundlePack(
 	{
 		version,
-		languages
+		translations
 	}: CKCdnBaseBundlePackConfig
 ): CKCdnResourcesAdvancedPack<Window['CKEDITOR']> {
 	const urls = {
@@ -39,8 +39,8 @@ export function createCKCdnBaseBundlePack(
 			createCKCdnUrl( 'ckeditor5', 'ckeditor5.umd.js', version ),
 
 			// Load all JavaScript files from the base features.
-			...( languages || [] ).map( language =>
-				createCKCdnUrl( 'ckeditor5', `translations/${ language }.umd.js`, version )
+			...( translations || [] ).map( translation =>
+				createCKCdnUrl( 'ckeditor5', `translations/${ translation }.umd.js`, version )
 			)
 		],
 
@@ -81,7 +81,7 @@ export type CKCdnBaseBundlePackConfig = {
 	version: CKCdnVersion;
 
 	/**
-	 * The list of languages to load.
+	 * The list of translations to load.
 	 */
-	languages?: Array<string>;
+	translations?: Array<string>;
 };

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -3,11 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '../loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../utils/loadCKCdnResourcesPack';
 
 import { createCKCdnUrl, type CKCdnVersion } from './createCKCdnUrl';
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { injectScriptsInParallel } from '../../utils/injectScript';
+import { without } from '../../utils/without';
 
 import './globals.d';
 
@@ -39,7 +40,8 @@ export function createCKCdnBaseBundlePack(
 			createCKCdnUrl( 'ckeditor5', 'ckeditor5.umd.js', version ),
 
 			// Load all JavaScript files from the base features.
-			...( translations || [] ).map( translation =>
+			// EN bundle is prebuilt into the main script, so we don't need to load it separately.
+			...without( [ 'en' ], translations || [] ).map( translation =>
 				createCKCdnUrl( 'ckeditor5', `translations/${ translation }.umd.js`, version )
 			)
 		],

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -23,7 +23,7 @@ import './globals.d';
  * const { Paragraph } = await loadCKCdnResourcesPack(
  * 	createCKCdnBaseBundlePack( {
  * 		version: '43.0.0',
- * 		translations: [ 'en', 'de' ]
+ * 		translations: [ 'es', 'de' ]
  * 	} )
  * );
  * ```

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -23,7 +23,7 @@ import './globals.d';
  * const { SlashCommand } = await loadCKCdnResourcesPack(
  * 	createCKCdnPremiumBundlePack( {
  * 		version: '43.0.0',
- * 		languages: [ 'en', 'de' ]
+ * 		translations: [ 'en', 'de' ]
  * 	} )
  * );
  * ```
@@ -31,7 +31,7 @@ import './globals.d';
 export function createCKCdnPremiumBundlePack(
 	{
 		version,
-		languages
+		translations
 	}: CKCdnPremiumBundlePackConfig
 ): CKCdnResourcesAdvancedPack<Window['CKEDITOR_PREMIUM_FEATURES']> {
 	const urls = {
@@ -40,8 +40,8 @@ export function createCKCdnPremiumBundlePack(
 			createCKCdnUrl( 'ckeditor5-premium-features', 'ckeditor5-premium-features.umd.js', version ),
 
 			// Load all JavaScript files from the premium features.
-			...( languages || [] ).map( language =>
-				createCKCdnUrl( 'ckeditor5-premium-features', `translations/${ language }.umd.js`, version )
+			...( translations || [] ).map( translation =>
+				createCKCdnUrl( 'ckeditor5-premium-features', `translations/${ translation }.umd.js`, version )
 			)
 		],
 
@@ -76,5 +76,5 @@ export function createCKCdnPremiumBundlePack(
  */
 export type CKCdnPremiumBundlePackConfig = Pick<
 	CKCdnBaseBundlePackConfig,
-	'languages' | 'version'
+	'translations' | 'version'
 >;

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -3,12 +3,13 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '../loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../utils/loadCKCdnResourcesPack';
 import type { CKCdnBaseBundlePackConfig } from './createCKCdnBaseBundlePack';
 
 import { createCKCdnUrl } from './createCKCdnUrl';
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { injectScriptsInParallel } from '../../utils/injectScript';
+import { without } from '../../utils/without';
 
 import './globals.d';
 
@@ -40,7 +41,8 @@ export function createCKCdnPremiumBundlePack(
 			createCKCdnUrl( 'ckeditor5-premium-features', 'ckeditor5-premium-features.umd.js', version ),
 
 			// Load all JavaScript files from the premium features.
-			...( translations || [] ).map( translation =>
+			// EN bundle is prebuilt into the main script, so we don't need to load it separately.
+			...without( [ 'en' ], translations || [] ).map( translation =>
 				createCKCdnUrl( 'ckeditor5-premium-features', `translations/${ translation }.umd.js`, version )
 			)
 		],

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -24,7 +24,7 @@ import './globals.d';
  * const { SlashCommand } = await loadCKCdnResourcesPack(
  * 	createCKCdnPremiumBundlePack( {
  * 		version: '43.0.0',
- * 		translations: [ 'en', 'de' ]
+ * 		translations: [ 'es', 'de' ]
  * 	} )
  * );
  * ```

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '../loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../utils/loadCKCdnResourcesPack';
 
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 import { createCKBoxCdnUrl, type CKBoxCdnVersion } from './createCKBoxCdnUrl';

--- a/src/cdn/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/combineCKCdnBundlesPacks.ts
@@ -24,11 +24,11 @@ import {
  * 	combineCKCdnBundlesPacks( {
  * 		Base: createCKCdnBaseBundlePack( {
  * 			version: '43.0.0',
- * 			languages: [ 'en', 'de' ]
+ * 			translations: [ 'en', 'de' ]
  * 		} ),
  * 		Premium: createCKCdnPremiumBundlePack( {
  * 			version: '43.0.0',
- * 			languages: [ 'en', 'de' ]
+ * 			translations: [ 'en', 'de' ]
  * 		} )
  * 	} )
  * );

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -39,7 +39,7 @@ import {
  * ```ts
  * const { CKEditor, CKEditorPremiumFeatures } = await loadCKEditorCloud( {
  * 	version: '43.0.0',
- * 	translations: [ 'en', 'de' ],
+ * 	translations: [ 'es', 'de' ],
  * 	premium: true
  * } );
  *

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -6,7 +6,7 @@
 import { createCKCdnBaseBundlePack } from './ck/createCKCdnBaseBundlePack';
 import { createCKCdnPremiumBundlePack } from './ck/createCKCdnPremiumBundlePack';
 
-import { combineCKCdnBundlesPacks } from './combineCKCdnBundlesPacks';
+import { combineCKCdnBundlesPacks } from './utils/combineCKCdnBundlesPacks';
 import {
 	createCKBoxBundlePack,
 	type CKBoxCdnBundlePackConfig
@@ -18,7 +18,7 @@ import type { CKCdnVersion } from './ck/createCKCdnUrl';
 import {
 	loadCKCdnResourcesPack,
 	type InferCKCdnResourcesPackExportsType
-} from './loadCKCdnResourcesPack';
+} from './utils/loadCKCdnResourcesPack';
 
 import {
 	combineCdnPluginsPacks,

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -39,7 +39,7 @@ import {
  * ```ts
  * const { CKEditor, CKEditorPremiumFeatures } = await loadCKEditorCloud( {
  * 	version: '43.0.0',
- * 	languages: [ 'en', 'de' ],
+ * 	translations: [ 'en', 'de' ],
  * 	premium: true
  * } );
  *
@@ -76,20 +76,20 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 	config: Config
 ): Promise<CKEditorCloudResult<Config>> {
 	const {
-		version, languages, plugins,
+		version, translations, plugins,
 		premium, ckbox
 	} = config;
 
 	const pack = combineCKCdnBundlesPacks( {
 		CKEditor: createCKCdnBaseBundlePack( {
 			version,
-			languages
+			translations
 		} ),
 
 		...premium && {
 			CKEditorPremiumFeatures: createCKCdnPremiumBundlePack( {
 				version,
-				languages
+				translations
 			} )
 		},
 
@@ -150,9 +150,9 @@ export type CKEditorCloudConfig<Plugins extends CdnPluginsPacks = CdnPluginsPack
 	version: CKCdnVersion;
 
 	/**
-	 * The languages to load.
+	 * The translations to load.
 	 */
-	languages?: Array<string>;
+	translations?: Array<string>;
 
 	/**
 	 * If `true` then the premium features will be loaded.

--- a/src/cdn/plugins/combineCdnPluginsPacks.ts
+++ b/src/cdn/plugins/combineCdnPluginsPacks.ts
@@ -10,12 +10,12 @@ import {
 	normalizeCKCdnResourcesPack,
 	type InferCKCdnResourcesPackExportsType,
 	type CKCdnResourcesAdvancedPack
-} from '../loadCKCdnResourcesPack';
+} from '../utils/loadCKCdnResourcesPack';
 
 import {
 	combineCKCdnBundlesPacks,
 	type CKCdnBundlesPacks
-} from '../combineCKCdnBundlesPacks';
+} from '../utils/combineCKCdnBundlesPacks';
 
 /**
  * This function is similar to `combineCKCdnBundlesPacks` but it provides global scope

--- a/src/cdn/utils/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/utils/combineCKCdnBundlesPacks.ts
@@ -3,8 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
-import { filterBlankObjectValues } from '../utils/filterBlankObjectValues';
-import { mapObjectValues } from '../utils/mapObjectValues';
+import { filterBlankObjectValues } from '../../utils/filterBlankObjectValues';
+import { mapObjectValues } from '../../utils/mapObjectValues';
 import {
 	normalizeCKCdnResourcesPack,
 	type CKCdnResourcesPack,

--- a/src/cdn/utils/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/utils/combineCKCdnBundlesPacks.ts
@@ -24,11 +24,11 @@ import {
  * 	combineCKCdnBundlesPacks( {
  * 		Base: createCKCdnBaseBundlePack( {
  * 			version: '43.0.0',
- * 			translations: [ 'en', 'de' ]
+ * 			translations: [ 'es', 'de' ]
  * 		} ),
  * 		Premium: createCKCdnPremiumBundlePack( {
  * 			version: '43.0.0',
- * 			translations: [ 'en', 'de' ]
+ * 			translations: [ 'es', 'de' ]
  * 		} )
  * 	} )
  * );

--- a/src/cdn/utils/loadCKCdnResourcesPack.ts
+++ b/src/cdn/utils/loadCKCdnResourcesPack.ts
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { Awaitable } from '../types/Awaitable';
+import type { Awaitable } from '../../types/Awaitable';
 
-import { injectScript } from '../utils/injectScript';
-import { injectStylesheet } from '../utils/injectStylesheet';
-import { preloadResource } from '../utils/preloadResource';
-import { uniq } from '../utils/uniq';
+import { injectScript } from '../../utils/injectScript';
+import { injectStylesheet } from '../../utils/injectStylesheet';
+import { preloadResource } from '../../utils/preloadResource';
+import { uniq } from '../../utils/uniq';
 
 /**
  * Loads pack of resources (scripts and stylesheets) and returns the exported global variables (if any).

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { waitForWindowEntry } from './utils/waitForWindowEntry';
 export { filterObjectValues } from './utils/filterObjectValues';
 export { filterBlankObjectValues } from './utils/filterBlankObjectValues';
 export { mapObjectValues } from './utils/mapObjectValues';
+export { without } from './utils/without';
 
 export {
 	CK_CDN_URL,

--- a/src/utils/without.ts
+++ b/src/utils/without.ts
@@ -1,0 +1,15 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Removes items from an array by values.
+ *
+ * @param itemsToRemove Items to remove.
+ * @param items Array to remove items from.
+ * @returns Array without removed items.
+ */
+export function without<A>( itemsToRemove: Array<A>, items: Array<A> ): Array<A> {
+	return items.filter( item => !itemsToRemove.includes( item ) );
+}

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -13,7 +13,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 	it( 'should create a pack of resources for the base CKEditor bundle', () => {
 		const config: CKCdnBaseBundlePackConfig = {
 			version: '43.0.0',
-			translations: [ 'en', 'de' ]
+			translations: [ 'pl', 'de' ]
 		};
 
 		const pack = createCKCdnBaseBundlePack( config );
@@ -21,7 +21,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 		expect( pack.preload ).toEqual( [
 			'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.css',
 			'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.umd.js',
-			'https://cdn.ckeditor.com/ckeditor5/43.0.0/translations/en.umd.js',
+			'https://cdn.ckeditor.com/ckeditor5/43.0.0/translations/pl.umd.js',
 			'https://cdn.ckeditor.com/ckeditor5/43.0.0/translations/de.umd.js'
 		] );
 
@@ -33,6 +33,28 @@ describe( 'createCKCdnBaseBundlePack', () => {
 		] );
 
 		expect( pack.checkPluginLoaded ).toBeInstanceOf( Function );
+	} );
+
+	it( 'should not load default EN translation script as it is already bundled', () => {
+		const pack = createCKCdnBaseBundlePack( {
+			version: '43.0.0',
+			translations: [ 'en', 'en-GB' ]
+		} );
+
+		expect( pack ).to.toMatchObject( {
+			checkPluginLoaded: expect.any( Function ),
+			stylesheets: [
+				'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.css'
+			],
+			scripts: [
+				expect.any( Function )
+			],
+			preload: [
+				'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.css',
+				'https://cdn.ckeditor.com/ckeditor5/43.0.0/ckeditor5.umd.js',
+				'https://cdn.ckeditor.com/ckeditor5/43.0.0/translations/en-GB.umd.js'
+			]
+		} );
 	} );
 
 	it( 'should not load any language if not provided', () => {

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -13,7 +13,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 	it( 'should create a pack of resources for the base CKEditor bundle', () => {
 		const config: CKCdnBaseBundlePackConfig = {
 			version: '43.0.0',
-			languages: [ 'en', 'de' ]
+			translations: [ 'en', 'de' ]
 		};
 
 		const pack = createCKCdnBaseBundlePack( config );

--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -10,7 +10,7 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 	it( 'should return a pack of resources for the CKEditor Premium Features', () => {
 		const pack = createCKCdnPremiumBundlePack( {
 			version: '43.0.0',
-			translations: [ 'en', 'de' ]
+			translations: [ 'es', 'de' ]
 		} );
 
 		expect( pack.preload ).toEqual( [

--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -10,7 +10,7 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 	it( 'should return a pack of resources for the CKEditor Premium Features', () => {
 		const pack = createCKCdnPremiumBundlePack( {
 			version: '43.0.0',
-			languages: [ 'en', 'de' ]
+			translations: [ 'en', 'de' ]
 		} );
 
 		expect( pack.preload ).toEqual( [

--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -16,7 +16,6 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 		expect( pack.preload ).toEqual( [
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css',
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.umd.js',
-			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/translations/en.umd.js',
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/translations/de.umd.js'
 		] );
 
@@ -26,6 +25,28 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 		] );
 
 		expect( pack.checkPluginLoaded ).toBeInstanceOf( Function );
+	} );
+
+	it( 'should not load default EN translation script as it is already bundled', () => {
+		const pack = createCKCdnPremiumBundlePack( {
+			version: '43.0.0',
+			translations: [ 'en', 'en-GB' ]
+		} );
+
+		expect( pack ).to.toMatchObject( {
+			checkPluginLoaded: expect.any( Function ),
+			stylesheets: [
+				'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css'
+			],
+			scripts: [
+				expect.any( Function )
+			],
+			preload: [
+				'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css',
+				'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.umd.js',
+				'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/translations/en-GB.umd.js'
+			]
+		} );
 	} );
 
 	it( 'should not load any language if not provided', () => {

--- a/tests/cdn/utils/combineCKCdnBundlesPacks.test.ts
+++ b/tests/cdn/utils/combineCKCdnBundlesPacks.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { combineCKCdnBundlesPacks } from '@/cdn/combineCKCdnBundlesPacks';
+import { combineCKCdnBundlesPacks } from '@/cdn/utils/combineCKCdnBundlesPacks';
 
 describe( 'combineCKCdnBundlesPacks', () => {
 	it( 'should combine multiple CKEditor CDN bundles packs into a single pack', async () => {

--- a/tests/cdn/utils/loadCKCdnResourcesPack.test.ts
+++ b/tests/cdn/utils/loadCKCdnResourcesPack.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, vi, expect, vitest, beforeEach, afterEach } from 'vitest';
 
-import { loadCKCdnResourcesPack } from '@/cdn/loadCKCdnResourcesPack';
+import { loadCKCdnResourcesPack } from '@/cdn/utils/loadCKCdnResourcesPack';
 import { createCKCdnUrl } from '@/cdn/ck/createCKCdnUrl';
 import {
 	queryScript,

--- a/tests/utils/without.test.ts
+++ b/tests/utils/without.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { without } from '@/utils/without';
+
+describe( 'without', () => {
+	it( 'should remove specified items from the array', () => {
+		const items = [ 1, 2, 3, 4, 5 ];
+		const itemsToRemove = [ 2, 4 ];
+		const result = without( itemsToRemove, items );
+		expect( result ).toEqual( [ 1, 3, 5 ] );
+	} );
+
+	it( 'should return the same array if no items are removed', () => {
+		const items = [ 1, 2, 3 ];
+		const itemsToRemove = [ 4, 5 ];
+		const result = without( itemsToRemove, items );
+		expect( result ).toEqual( [ 1, 2, 3 ] );
+	} );
+
+	it( 'should return an empty array if all items are removed', () => {
+		const items = [ 1, 2, 3 ];
+		const itemsToRemove = [ 1, 2, 3 ];
+		const result = without( itemsToRemove, items );
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should handle an empty array of items to remove', () => {
+		const items = [ 1, 2, 3 ];
+		const itemsToRemove: Array<number> = [];
+		const result = without( itemsToRemove, items );
+		expect( result ).toEqual( [ 1, 2, 3 ] );
+	} );
+
+	it( 'should handle an empty array of items', () => {
+		const items: Array<number> = [];
+		const itemsToRemove = [ 1, 2, 3 ];
+		const result = without( itemsToRemove, items );
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should handle arrays with different types of items', () => {
+		const items = [ 1, '2', 3, '4', 5 ];
+		const itemsToRemove = [ '2', 4 ];
+		const result = without( itemsToRemove, items );
+		expect( result ).toEqual( [ 1, 3, '4', 5 ] );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Rename the `languages` configuration property to `translations` in `loadCKEditorCloud`.
Feature: The `en` language is no longer loaded when passed in `translations` as it is prebundled.

MINOR BREAKING CHANGE: The `languages` configuration property has been renamed to `translations` in `loadCKEditorCloud`.