### PR TITLE
Fix missing `es.umd.js` in integration tests

### DIFF
--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -16,6 +16,7 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 		expect( pack.preload ).toEqual( [
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.css',
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/ckeditor5-premium-features.umd.js',
+			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/translations/es.umd.js',
 			'https://cdn.ckeditor.com/ckeditor5-premium-features/43.0.0/translations/de.umd.js'
 		] );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix failing tests.