### PR TITLE
Add `crossorigin=anonymous` attribute to all inserted CDN resources tags

### DIFF
--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -60,7 +60,7 @@ export function createCKCdnBaseBundlePack(
 
 		scripts: [
 			// It's safe to load translations and the main script in parallel.
-			async () => injectScriptsInParallel( urls.scripts )
+			async attributes => injectScriptsInParallel( urls.scripts, attributes )
 		],
 
 		// Load all stylesheets of the base features.

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -61,7 +61,7 @@ export function createCKCdnPremiumBundlePack(
 
 		scripts: [
 			// It's safe to load translations and the main script in parallel.
-			async () => injectScriptsInParallel( urls.scripts )
+			async attributes => injectScriptsInParallel( urls.scripts, attributes )
 		],
 
 		// Load all stylesheets of the premium features.

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -77,7 +77,7 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 ): Promise<CKEditorCloudResult<Config>> {
 	const {
 		version, translations, plugins,
-		premium, ckbox
+		premium, ckbox, injectedHtmlElementsAttributes
 	} = config;
 
 	const pack = combineCKCdnBundlesPacks( {
@@ -100,7 +100,15 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 		loadedPlugins: combineCdnPluginsPacks( plugins ?? {} )
 	} );
 
-	return loadCKCdnResourcesPack( pack ) as Promise<CKEditorCloudResult<Config>>;
+	return loadCKCdnResourcesPack(
+		{
+			...pack,
+			htmlAttributes: {
+				crossorigin: 'anonymous',
+				...injectedHtmlElementsAttributes
+			}
+		}
+	) as Promise<CKEditorCloudResult<Config>>;
 }
 
 /**
@@ -168,4 +176,9 @@ export type CKEditorCloudConfig<Plugins extends CdnPluginsPacks = CdnPluginsPack
 	 * Additional resources to load.
 	 */
 	plugins?: Plugins;
+
+	/**
+	 * Map of attributes to add to the script, stylesheet and link tags that are injected by the loader.
+	 */
+	injectedHtmlElementsAttributes?: Record<string, any>;
 };

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -77,7 +77,10 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 ): Promise<CKEditorCloudResult<Config>> {
 	const {
 		version, translations, plugins,
-		premium, ckbox, injectedHtmlElementsAttributes
+		premium, ckbox,
+		injectedHtmlElementsAttributes = {
+			crossorigin: 'anonymous'
+		}
 	} = config;
 
 	const pack = combineCKCdnBundlesPacks( {
@@ -103,10 +106,7 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 	return loadCKCdnResourcesPack(
 		{
 			...pack,
-			htmlAttributes: {
-				crossorigin: 'anonymous',
-				...injectedHtmlElementsAttributes
-			}
+			htmlAttributes: injectedHtmlElementsAttributes
 		}
 	) as Promise<CKEditorCloudResult<Config>>;
 }

--- a/src/cdn/utils/loadCKCdnResourcesPack.ts
+++ b/src/cdn/utils/loadCKCdnResourcesPack.ts
@@ -43,7 +43,9 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 	}
 
 	// Preload resources specified in the pack.
-	preload.forEach( preloadResource );
+	for ( const url of preload ) {
+		preloadResource( url );
+	}
 
 	// Load stylesheet tags before scripts to avoid a flash of unstyled content.
 	await Promise.all(

--- a/src/utils/injectScript.ts
+++ b/src/utils/injectScript.ts
@@ -13,9 +13,18 @@ export const INJECTED_SCRIPTS = new Map<string, Promise<void>>();
  * Injects a script into the document.
  *
  * @param src The URL of the script to be injected.
+ * @param props Additional properties used to decide how the script should be injected.
+ * @param props.attributes Additional attributes to be set on the script element.
  * @returns A promise that resolves when the script is loaded.
  */
-export function injectScript( src: string ): Promise<void> {
+export function injectScript(
+	src: string,
+	{ attributes }: InjectScriptProps = {
+		attributes: {
+			crossorigin: 'anonymous'
+		}
+	}
+): Promise<void> {
 	// Return the promise if the script is already injected by this function.
 	if ( INJECTED_SCRIPTS.has( src ) ) {
 		return INJECTED_SCRIPTS.get( src )!;
@@ -40,6 +49,12 @@ export function injectScript( src: string ): Promise<void> {
 		};
 
 		script.setAttribute( 'data-injected-by', 'ckeditor-integration' );
+
+		// Set additional attributes if provided.
+		for ( const [ key, value ] of Object.entries( attributes || {} ) ) {
+			script.setAttribute( key, value );
+		}
+
 		script.type = 'text/javascript';
 		script.async = true;
 		script.src = src;
@@ -68,11 +83,21 @@ export function injectScript( src: string ): Promise<void> {
 }
 
 /**
+ * Props for the `injectScript` function.
+ */
+type InjectScriptProps = {
+	attributes?: Record<string, any>;
+};
+
+/**
  * Injects multiple scripts into the document in parallel.
  *
  * @param sources The URLs of the scripts to be injected.
+ * @param props Additional properties used to decide how the script should be injected.
  * @returns A promise that resolves when all scripts are loaded.
  */
-export async function injectScriptsInParallel( sources: Array<string> ): Promise<void> {
-	await Promise.all( sources.map( injectScript ) );
+export async function injectScriptsInParallel( sources: Array<string>, props?: InjectScriptProps ): Promise<void> {
+	await Promise.all(
+		sources.map( src => injectScript( src, props ) )
+	);
 }

--- a/src/utils/injectScript.ts
+++ b/src/utils/injectScript.ts
@@ -19,11 +19,7 @@ export const INJECTED_SCRIPTS = new Map<string, Promise<void>>();
  */
 export function injectScript(
 	src: string,
-	{ attributes }: InjectScriptProps = {
-		attributes: {
-			crossorigin: 'anonymous'
-		}
-	}
+	{ attributes }: InjectScriptProps = {}
 ): Promise<void> {
 	// Return the promise if the script is already injected by this function.
 	if ( INJECTED_SCRIPTS.has( src ) ) {
@@ -85,7 +81,7 @@ export function injectScript(
 /**
  * Props for the `injectScript` function.
  */
-type InjectScriptProps = {
+export type InjectScriptProps = {
 	attributes?: Record<string, any>;
 };
 

--- a/src/utils/injectScript.ts
+++ b/src/utils/injectScript.ts
@@ -44,12 +44,12 @@ export function injectScript(
 			resolve();
 		};
 
-		script.setAttribute( 'data-injected-by', 'ckeditor-integration' );
-
 		// Set additional attributes if provided.
 		for ( const [ key, value ] of Object.entries( attributes || {} ) ) {
 			script.setAttribute( key, value );
 		}
+
+		script.setAttribute( 'data-injected-by', 'ckeditor-integration' );
 
 		script.type = 'text/javascript';
 		script.async = true;

--- a/src/utils/injectStylesheet.ts
+++ b/src/utils/injectStylesheet.ts
@@ -21,9 +21,7 @@ export function injectStylesheet(
 	{
 		href,
 		placementInHead = 'start',
-		attributes = {
-			crossorigin: 'anonymous'
-		}
+		attributes = {}
 	}: InjectStylesheetProps
 ): Promise<void> {
 	// Return the promise if the stylesheet is already injected by this function.

--- a/src/utils/injectStylesheet.ts
+++ b/src/utils/injectStylesheet.ts
@@ -69,12 +69,12 @@ export function injectStylesheet(
 	const promise = new Promise<void>( ( resolve, reject ) => {
 		const link = document.createElement( 'link' );
 
-		link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
-
 		// Set additional attributes if provided.
 		for ( const [ key, value ] of Object.entries( attributes || {} ) ) {
 			link.setAttribute( key, value );
 		}
+
+		link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
 
 		link.rel = 'stylesheet';
 		link.href = href;

--- a/src/utils/injectStylesheet.ts
+++ b/src/utils/injectStylesheet.ts
@@ -14,9 +14,18 @@ export const INJECTED_STYLESHEETS = new Map<string, Promise<void>>();
  *
  * @param props.href The URL of the stylesheet to be injected.
  * @param props.placementInHead The placement of the stylesheet in the head.
+ * @param props.attributes Additional attributes to be set on the link element.
  * @returns A promise that resolves when the stylesheet is loaded.
  */
-export function injectStylesheet( { href, placementInHead = 'start' }: InjectStylesheetProps ): Promise<void> {
+export function injectStylesheet(
+	{
+		href,
+		placementInHead = 'start',
+		attributes = {
+			crossorigin: 'anonymous'
+		}
+	}: InjectStylesheetProps
+): Promise<void> {
 	// Return the promise if the stylesheet is already injected by this function.
 	if ( INJECTED_STYLESHEETS.has( href ) ) {
 		return INJECTED_STYLESHEETS.get( href )!;
@@ -63,6 +72,12 @@ export function injectStylesheet( { href, placementInHead = 'start' }: InjectSty
 		const link = document.createElement( 'link' );
 
 		link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
+
+		// Set additional attributes if provided.
+		for ( const [ key, value ] of Object.entries( attributes || {} ) ) {
+			link.setAttribute( key, value );
+		}
+
 		link.rel = 'stylesheet';
 		link.href = href;
 
@@ -109,4 +124,9 @@ type InjectStylesheetProps = {
 	 * of the head. Default is 'start' because it allows user to override the styles easily.
 	 */
 	placementInHead?: 'start' | 'end';
+
+	/**
+	 * Additional attributes to set on the link tag.
+	 */
+	attributes?: Record<string, any>;
 };

--- a/src/utils/preloadResource.ts
+++ b/src/utils/preloadResource.ts
@@ -8,8 +8,19 @@
  *
  * 	* It should detect if the resource is already preloaded.
  * 	* It should detect type of the resource and set the `as` attribute accordingly.
+ *
+ * @param url The URL of the resource to preload.
+ * @param props Additional properties for the preload.
+ * @param props.attributes Additional attributes to be set on the `<link>` element.
  */
-export function preloadResource( url: string ): void {
+export function preloadResource(
+	url: string,
+	{ attributes }: PreloadResourceProps = {
+		attributes: {
+			crossorigin: 'anonymous'
+		}
+	}
+): void {
 	if ( document.head.querySelector( `link[href="${ url }"][rel="preload"]` ) ) {
 		return;
 	}
@@ -17,12 +28,25 @@ export function preloadResource( url: string ): void {
 	const link = document.createElement( 'link' );
 
 	link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
+
+	// Set additional attributes if provided.
+	for ( const [ key, value ] of Object.entries( attributes || {} ) ) {
+		link.setAttribute( key, value );
+	}
+
 	link.rel = 'preload';
 	link.as = detectTypeOfResource( url );
 	link.href = url;
 
 	document.head.insertBefore( link, document.head.firstChild );
 }
+
+/**
+ * Properties for the `preloadResource` function.
+ */
+type PreloadResourceProps = {
+	attributes?: Record<string, any>;
+};
 
 /**
  * Detects the type of the resource based on its URL.

--- a/src/utils/preloadResource.ts
+++ b/src/utils/preloadResource.ts
@@ -23,12 +23,12 @@ export function preloadResource(
 
 	const link = document.createElement( 'link' );
 
-	link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
-
 	// Set additional attributes if provided.
 	for ( const [ key, value ] of Object.entries( attributes || {} ) ) {
 		link.setAttribute( key, value );
 	}
+
+	link.setAttribute( 'data-injected-by', 'ckeditor-integration' );
 
 	link.rel = 'preload';
 	link.as = detectTypeOfResource( url );

--- a/src/utils/preloadResource.ts
+++ b/src/utils/preloadResource.ts
@@ -15,11 +15,7 @@
  */
 export function preloadResource(
 	url: string,
-	{ attributes }: PreloadResourceProps = {
-		attributes: {
-			crossorigin: 'anonymous'
-		}
-	}
+	{ attributes }: PreloadResourceProps = {}
 ): void {
 	if ( document.head.querySelector( `link[href="${ url }"][rel="preload"]` ) ) {
 		return;

--- a/tests/_utils/queryInjectedElements.ts
+++ b/tests/_utils/queryInjectedElements.ts
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export function queryAllInjectedScripts(): Array<HTMLScriptElement> {
+	return [
+		...document.querySelectorAll( 'script[data-injected-by="ckeditor-integration"]' )
+	] as Array<HTMLScriptElement>;
+}
+
+export function queryAllInjectedLinks(): Array<HTMLLinkElement> {
+	return [
+		...document.querySelectorAll( 'link[data-injected-by="ckeditor-integration"]' )
+	] as Array<HTMLLinkElement>;
+}

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -110,12 +110,16 @@ describe( 'loadCKEditorCloud', () => {
 		} );
 
 		it( 'should be possible to override the `crossorigin` attribute', async () => {
+			const setAttributeSpy = vi.spyOn( HTMLElement.prototype, 'setAttribute' );
 			const promise = loadCKEditorCloud( {
 				version: '43.0.0',
 				injectedHtmlElementsAttributes: {
 					crossorigin: 'use-credentials'
 				}
 			} );
+
+			expect( setAttributeSpy ).toBeCalledWith( 'crossorigin', 'use-credentials' );
+			expect( setAttributeSpy ).toBeCalledTimes( 6 );
 
 			// It's fine because `use-credentials` throws an error in the vitest browser.
 			expect( promise ).rejects.toThrowError();

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -12,8 +12,9 @@ import type { AIAdapter } from 'ckeditor5-premium-features';
 
 import { loadCKEditorCloud } from '@/cdn/loadCKEditorCloud';
 import { createCKBoxBundlePack } from '@/cdn/ckbox/createCKBoxCdnBundlePack';
+import { CKBOX_CDN_URL, createCKBoxCdnUrl } from '@/cdn/ckbox/createCKBoxCdnUrl';
+
 import { removeCkCdnLinks, removeCkCdnScripts } from 'tests/_utils/ckCdnMocks';
-import { createCKBoxCdnUrl } from '@/cdn/ckbox/createCKBoxCdnUrl';
 
 describe( 'loadCKEditorCloud', () => {
 	beforeEach( () => {
@@ -76,6 +77,25 @@ describe( 'loadCKEditorCloud', () => {
 
 		expect( CKEditor.ClassicEditor ).toBeDefined();
 		expect( loadedPlugins?.Plugin ).toBeDefined();
+	} );
+
+	it( 'should set crossorigin=anonymous attribute on injected elements', async () => {
+		await loadCKEditorCloud( {
+			version: '43.0.0'
+		} );
+
+		const nonAnonymousLinks = [ ...document.querySelectorAll( 'link' ) ].filter( link =>
+			link.getAttribute( 'href' )?.includes( CKBOX_CDN_URL ) &&
+			link.getAttribute( 'crossorigin' ) !== 'anonymous'
+		);
+
+		const nonAnonymousScripts = [ ...document.querySelectorAll( 'script' ) ].filter( script =>
+			script.getAttribute( 'src' )?.includes( CKBOX_CDN_URL ) &&
+			script.getAttribute( 'crossorigin' ) !== 'anonymous'
+		);
+
+		expect( nonAnonymousLinks ).toHaveLength( 0 );
+		expect( nonAnonymousScripts ).toHaveLength( 0 );
 	} );
 
 	describe( 'typings', () => {

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -16,6 +16,10 @@ import { createCKBoxCdnUrl } from '@/cdn/ckbox/createCKBoxCdnUrl';
 
 import { queryPreload, queryScript, queryStylesheet, removeAllCkCdnResources } from '../_utils';
 import { createCKCdnUrl } from '@/src/cdn/ck/createCKCdnUrl';
+import {
+	queryAllInjectedLinks,
+	queryAllInjectedScripts
+} from '../_utils/queryInjectedElements';
 
 describe( 'loadCKEditorCloud', () => {
 	beforeEach( () => {
@@ -80,7 +84,7 @@ describe( 'loadCKEditorCloud', () => {
 	} );
 
 	describe( 'CSP', () => {
-		it( 'should set crossorigin=anonymous attribute on injected elements if `htmlAttributes` is not specified', async () => {
+		it( 'should set crossorigin=anonymous attribute on injected elements if attributes are not specified', async () => {
 			console.info( queryAnonymousLinks()[ 0 ] );
 
 			expect( queryAnonymousLinks() ).toHaveLength( 0 );
@@ -94,7 +98,7 @@ describe( 'loadCKEditorCloud', () => {
 			expect( queryAnonymousScripts() ).toHaveLength( 1 );
 		} );
 
-		it( 'should set crossorigin=anonymous attribute on injected elements if `htmlAttributes` is specified but is blank', async () => {
+		it( 'should not set crossorigin attribute on injected elements if attributes are specified but are blank', async () => {
 			expect( queryAnonymousLinks() ).toHaveLength( 0 );
 			expect( queryAnonymousScripts() ).toHaveLength( 0 );
 
@@ -103,8 +107,8 @@ describe( 'loadCKEditorCloud', () => {
 				injectedHtmlElementsAttributes: {}
 			} );
 
-			expect( queryAnonymousLinks() ).toHaveLength( 3 );
-			expect( queryAnonymousScripts() ).toHaveLength( 1 );
+			expect( queryAnonymousLinks() ).toHaveLength( 0 );
+			expect( queryAnonymousScripts() ).toHaveLength( 0 );
 		} );
 
 		it( 'should be possible to override the `crossorigin` attribute', async () => {
@@ -119,7 +123,7 @@ describe( 'loadCKEditorCloud', () => {
 			expect( promise ).rejects.toThrowError();
 		} );
 
-		it( 'should set nonce attribute on injected elements if `htmlAttributes` is specified', async () => {
+		it( 'should set nonce attribute on injected elements if attributes are specified', async () => {
 			await loadCKEditorCloud( {
 				version: '43.0.0',
 				injectedHtmlElementsAttributes: {
@@ -139,15 +143,11 @@ describe( 'loadCKEditorCloud', () => {
 		} );
 
 		function queryAnonymousScripts() {
-			return [ ...document.querySelectorAll( 'script[data-injected-by="ckeditor-integration"]' ) ].filter( script =>
-				script.getAttribute( 'crossorigin' ) === 'anonymous'
-			);
+			return queryAllInjectedScripts().filter( script => script.getAttribute( 'crossorigin' ) === 'anonymous' );
 		}
 
 		function queryAnonymousLinks() {
-			return [ ...document.querySelectorAll( 'link[data-injected-by="ckeditor-integration"]' ) ].filter( link =>
-				link.getAttribute( 'crossorigin' ) === 'anonymous'
-			);
+			return queryAllInjectedLinks().filter( link => link.getAttribute( 'crossorigin' ) === 'anonymous' );
 		}
 	} );
 

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -85,8 +85,6 @@ describe( 'loadCKEditorCloud', () => {
 
 	describe( 'CSP', () => {
 		it( 'should set crossorigin=anonymous attribute on injected elements if attributes are not specified', async () => {
-			console.info( queryAnonymousLinks()[ 0 ] );
-
 			expect( queryAnonymousLinks() ).toHaveLength( 0 );
 			expect( queryAnonymousScripts() ).toHaveLength( 0 );
 

--- a/tests/utils/injectScript.test.ts
+++ b/tests/utils/injectScript.test.ts
@@ -113,6 +113,13 @@ describe( 'injectScript', () => {
 		expect( queryScript( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBeNull();
 		await waitForExecuteMockScript();
 	} );
+
+	it( 'should not crash if attributes object is null', async () => {
+		await injectScript( CDN_MOCK_SCRIPT_URL, { attributes: null as any } );
+
+		expect( queryScript( CDN_MOCK_SCRIPT_URL ) ).not.toBeNull();
+		await waitForExecuteMockScript();
+	} );
 } );
 
 async function waitForExecuteMockScript() {

--- a/tests/utils/injectScript.test.ts
+++ b/tests/utils/injectScript.test.ts
@@ -6,7 +6,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CDN_MOCK_SCRIPT_URL, removeCkCdnScripts } from 'tests/_utils/ckCdnMocks';
-import { injectScript } from '@/utils/injectScript';
+import { queryScript } from 'tests/_utils';
+
+import { INJECTED_SCRIPTS, injectScript } from '@/utils/injectScript';
+import { createDefer } from '@/src/utils/defer';
 
 describe( 'injectScript', () => {
 	beforeEach( () => {
@@ -35,9 +38,8 @@ describe( 'injectScript', () => {
 		// Wait for the promise to resolve
 		await expect( promise ).resolves.toBeUndefined();
 
-		await vi.waitFor( () => {
-			expect( window.CKEDITOR ).toBeDefined();
-		}, { timeout: 500 } );
+		// Verify that the script was injected and then stop the test
+		await waitForExecuteMockScript();
 	} );
 
 	it( 'should return the same promise if the script is already injected', async () => {
@@ -51,25 +53,70 @@ describe( 'injectScript', () => {
 		// Wait for the promises to resolve
 		await expect( promise1 ).resolves.toBeUndefined();
 		await expect( promise2 ).resolves.toBeUndefined();
+
+		// Verify that the script was injected and then stop the test
+		await waitForExecuteMockScript();
 	} );
 
 	it( 'should show a warning if the script is already present in the document', async () => {
 		// Manually inject the script into the document.
+		const onLoadOriginalScript = createDefer();
 		const script = document.createElement( 'script' );
+
 		script.type = 'text/javascript';
 		script.src = CDN_MOCK_SCRIPT_URL;
+		script.onload = () => onLoadOriginalScript.resolve();
 
 		document.head.appendChild( script );
 
-		// Call the injectScript function
-		const promise = injectScript( CDN_MOCK_SCRIPT_URL );
+		await onLoadOriginalScript.promise;
+		await waitForExecuteMockScript();
 
-		// Wait for the promise to resolve
-		await expect( promise ).resolves.toBeUndefined();
+		// Spy on appendChild to make sure that the script is not appended again.
+		const appendChildSpy = vi
+			.spyOn( document.head, 'appendChild' )
+			.mockImplementation( () => document.createElement( 'script' ) );
+
+		injectScript( CDN_MOCK_SCRIPT_URL );
 
 		// Verify that the warning was shown
 		expect( console.warn ).toHaveBeenCalledWith(
 			`Script with "${ CDN_MOCK_SCRIPT_URL }" src is already present in DOM!`
 		);
+
+		appendChildSpy.mockRestore();
+		script.remove();
+		INJECTED_SCRIPTS.clear();
+	} );
+
+	it( 'should be possible to define custom attributes for the script element', async () => {
+		await injectScript( CDN_MOCK_SCRIPT_URL, {
+			attributes: {
+				'data-custom-attribute': 'custom-value'
+			}
+		} );
+
+		expect( queryScript( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'data-custom-attribute' ) ).toBe( 'custom-value' );
+		await waitForExecuteMockScript();
+	} );
+
+	it( 'should set crossorigin=anonymous attribute by default', async () => {
+		await injectScript( CDN_MOCK_SCRIPT_URL );
+
+		expect( queryScript( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBe( 'anonymous' );
+		await waitForExecuteMockScript();
+	} );
+
+	it( 'should not inject the crossorigin=anonymous if empty attributes object passed', async () => {
+		await injectScript( CDN_MOCK_SCRIPT_URL, { attributes: {} } );
+
+		expect( queryScript( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBeNull();
+		await waitForExecuteMockScript();
 	} );
 } );
+
+async function waitForExecuteMockScript() {
+	await vi.waitFor( () => {
+		expect( window.CKEDITOR ).toBeDefined();
+	}, { timeout: 500 } );
+}

--- a/tests/utils/injectScript.test.ts
+++ b/tests/utils/injectScript.test.ts
@@ -100,17 +100,10 @@ describe( 'injectScript', () => {
 		await waitForExecuteMockScript();
 	} );
 
-	it( 'should set crossorigin=anonymous attribute by default', async () => {
+	it( 'should not set crossorigin attribute by default', async () => {
 		await injectScript( CDN_MOCK_SCRIPT_URL );
 
-		expect( queryScript( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBe( 'anonymous' );
-		await waitForExecuteMockScript();
-	} );
-
-	it( 'should not inject the crossorigin=anonymous if empty attributes object passed', async () => {
-		await injectScript( CDN_MOCK_SCRIPT_URL, { attributes: {} } );
-
-		expect( queryScript( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBeNull();
+		expect( queryScript( CDN_MOCK_SCRIPT_URL )?.hasAttribute( 'crossorigin' ) ).toBe( false );
 		await waitForExecuteMockScript();
 	} );
 

--- a/tests/utils/injectStylesheet.test.ts
+++ b/tests/utils/injectStylesheet.test.ts
@@ -9,6 +9,7 @@ import { CDN_MOCK_STYLESHEET_URL, removeCkCdnLinks } from 'tests/_utils/ckCdnMoc
 import { injectStylesheet } from '@/utils/injectStylesheet';
 import { preloadResource } from '@/utils/preloadResource';
 import { createCKCdnUrl } from '@/cdn/ck/createCKCdnUrl';
+import { queryStylesheet } from '../_utils';
 
 describe( 'injectStylesheet', () => {
 	beforeEach( () => {
@@ -153,5 +154,37 @@ describe( 'injectStylesheet', () => {
 			[ 'preload', CDN_MOCK_STYLESHEET_URL ],
 			[ 'stylesheet', CDN_MOCK_STYLESHEET_URL ]
 		] );
+	} );
+
+	it( 'should be possible to define custom attributes for the stylesheet element', async () => {
+		await injectStylesheet( {
+			href: CDN_MOCK_STYLESHEET_URL,
+			attributes: {
+				'data-custom-attribute': 'custom-value'
+			}
+		} );
+
+		const element = queryStylesheet( CDN_MOCK_STYLESHEET_URL )?.getAttribute( 'data-custom-attribute' );
+
+		expect( element ).toEqual( 'custom-value' );
+	} );
+
+	it( 'should set crossorigin=anonymous attribute by default', async () => {
+		await injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL } );
+
+		const element = queryStylesheet( CDN_MOCK_STYLESHEET_URL )?.getAttribute( 'crossorigin' );
+
+		expect( element ).toEqual( 'anonymous' );
+	} );
+
+	it( 'should not inject the crossorigin=anonymous if empty attributes object passed', async () => {
+		await injectStylesheet( {
+			href: CDN_MOCK_STYLESHEET_URL,
+			attributes: {}
+		} );
+
+		const element = queryStylesheet( CDN_MOCK_STYLESHEET_URL )?.getAttribute( 'crossorigin' );
+
+		expect( element ).toBeNull();
 	} );
 } );

--- a/tests/utils/injectStylesheet.test.ts
+++ b/tests/utils/injectStylesheet.test.ts
@@ -187,4 +187,13 @@ describe( 'injectStylesheet', () => {
 
 		expect( element ).toBeNull();
 	} );
+
+	it( 'should not crash if attributes object is null', async () => {
+		await injectStylesheet( {
+			href: CDN_MOCK_STYLESHEET_URL,
+			attributes: null as any
+		} );
+
+		expect( queryStylesheet( CDN_MOCK_STYLESHEET_URL ) ).not.toBeNull();
+	} );
 } );

--- a/tests/utils/injectStylesheet.test.ts
+++ b/tests/utils/injectStylesheet.test.ts
@@ -169,23 +169,10 @@ describe( 'injectStylesheet', () => {
 		expect( element ).toEqual( 'custom-value' );
 	} );
 
-	it( 'should set crossorigin=anonymous attribute by default', async () => {
+	it( 'should not set crossorigin attribute by default', async () => {
 		await injectStylesheet( { href: CDN_MOCK_STYLESHEET_URL } );
 
-		const element = queryStylesheet( CDN_MOCK_STYLESHEET_URL )?.getAttribute( 'crossorigin' );
-
-		expect( element ).toEqual( 'anonymous' );
-	} );
-
-	it( 'should not inject the crossorigin=anonymous if empty attributes object passed', async () => {
-		await injectStylesheet( {
-			href: CDN_MOCK_STYLESHEET_URL,
-			attributes: {}
-		} );
-
-		const element = queryStylesheet( CDN_MOCK_STYLESHEET_URL )?.getAttribute( 'crossorigin' );
-
-		expect( element ).toBeNull();
+		expect( queryStylesheet( CDN_MOCK_STYLESHEET_URL )?.hasAttribute( 'crossorigin' ) ).toEqual( false );
 	} );
 
 	it( 'should not crash if attributes object is null', async () => {

--- a/tests/utils/preloadResource.test.ts
+++ b/tests/utils/preloadResource.test.ts
@@ -61,16 +61,10 @@ describe( 'preloadResource', () => {
 		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'data-custom-attribute' ) ).toBe( 'custom-value' );
 	} );
 
-	it( 'should set crossorigin=anonymous attribute by default', () => {
-		preloadResource( CDN_MOCK_SCRIPT_URL );
-
-		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBe( 'anonymous' );
-	} );
-
-	it( 'should not inject the crossorigin=anonymous if empty attributes object passed', () => {
+	it( 'should not inject the crossorigin if empty attributes object passed', () => {
 		preloadResource( CDN_MOCK_SCRIPT_URL, { attributes: {} } );
 
-		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBeNull();
+		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.hasAttribute( 'crossorigin' ) ).toBe( false );
 	} );
 
 	it( 'should not crash if attributes object is null', () => {

--- a/tests/utils/preloadResource.test.ts
+++ b/tests/utils/preloadResource.test.ts
@@ -72,4 +72,10 @@ describe( 'preloadResource', () => {
 
 		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBeNull();
 	} );
+
+	it( 'should not crash if attributes object is null', () => {
+		preloadResource( CDN_MOCK_SCRIPT_URL, { attributes: null as any } );
+
+		expect( queryPreload( CDN_MOCK_SCRIPT_URL ) ).not.toBeNull();
+	} );
 } );

--- a/tests/utils/preloadResource.test.ts
+++ b/tests/utils/preloadResource.test.ts
@@ -5,6 +5,8 @@
 
 import { describe, expect, it, beforeEach } from 'vitest';
 import { preloadResource } from '@/utils/preloadResource';
+
+import { queryPreload } from 'tests/_utils';
 import {
 	CDN_MOCK_SCRIPT_URL,
 	CDN_MOCK_STYLESHEET_URL
@@ -46,8 +48,28 @@ describe( 'preloadResource', () => {
 
 		preloadResource( url );
 
-		const otherLinkElement = document.head.querySelector( `link[href="${ url }"][rel="preload"]` );
+		expect( queryPreload( url )!.getAttribute( 'as' ) ).toBe( 'fetch' );
+	} );
 
-		expect( otherLinkElement!.getAttribute( 'as' ) ).toBe( 'fetch' );
+	it( 'should allow to set additional attributes', () => {
+		preloadResource( CDN_MOCK_SCRIPT_URL, {
+			attributes: {
+				'data-custom-attribute': 'custom-value'
+			}
+		} );
+
+		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'data-custom-attribute' ) ).toBe( 'custom-value' );
+	} );
+
+	it( 'should set crossorigin=anonymous attribute by default', () => {
+		preloadResource( CDN_MOCK_SCRIPT_URL );
+
+		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBe( 'anonymous' );
+	} );
+
+	it( 'should not inject the crossorigin=anonymous if empty attributes object passed', () => {
+		preloadResource( CDN_MOCK_SCRIPT_URL, { attributes: {} } );
+
+		expect( queryPreload( CDN_MOCK_SCRIPT_URL )?.getAttribute( 'crossorigin' ) ).toBeNull();
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add the `crossorigin=anonymous` attribute to all CDN resource tags to prevent CORS issues. Closes https://github.com/ckeditor/ckeditor5-integrations-common/issues/30.
Feature: Add the `injectedHtmlElementsAttributes` attribute to the `loadCKEditorCloud` configuration, allowing the addition of `nonce` and other custom attributes to injected elements.
