### PR TITLE
Improve CDN installation errors

### DIFF
--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -88,8 +88,8 @@ export function createCKCdnBaseBundlePack(
 				case 'cdn':
 					if ( installationInfo.version !== version ) {
 						throw new Error(
-							`CKEditor 5 version ${ installationInfo.version } is already loaded from CDN. ` +
-							`The requested version is ${ version }.`
+							`CKEditor 5 is already loaded from CDN in version ${ installationInfo.version }. ` +
+                            `Remove the old <script> and <link> tags loading CKEditor 5 to allow loading the ${ version } version.`
 						);
 					}
 

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -89,7 +89,7 @@ export function createCKCdnBaseBundlePack(
 					if ( installationInfo.version !== version ) {
 						throw new Error(
 							`CKEditor 5 is already loaded from CDN in version ${ installationInfo.version }. ` +
-                            `Remove the old <script> and <link> tags loading CKEditor 5 to allow loading the ${ version } version.`
+							`Remove the old <script> and <link> tags loading CKEditor 5 to allow loading the ${ version } version.`
 						);
 					}
 

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -3,12 +3,16 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '../utils/loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '@/cdn/utils/loadCKCdnResourcesPack';
+
+import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
+import { injectScriptsInParallel } from '@/utils/injectScript';
+import { without } from '@/utils/without';
+
+import { getCKBaseBundleInstallationInfo } from '@/installation-info/getCKBaseBundleInstallationInfo';
+import { createCKDocsUrl } from '@/docs/createCKDocsUrl';
 
 import { createCKCdnUrl, type CKCdnVersion } from './createCKCdnUrl';
-import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
-import { injectScriptsInParallel } from '../../utils/injectScript';
-import { without } from '../../utils/without';
 
 import './globals.d';
 
@@ -68,7 +72,30 @@ export function createCKCdnBaseBundlePack(
 
 		// Pick the exported global variables from the window object.
 		checkPluginLoaded: async () =>
-			waitForWindowEntry( [ 'CKEDITOR' ] )
+			waitForWindowEntry( [ 'CKEDITOR' ] ),
+
+		// Check if the CKEditor base bundle is already loaded and throw an error if it is.
+		beforeInject: () => {
+			const installationInfo = getCKBaseBundleInstallationInfo();
+
+			switch ( installationInfo?.source ) {
+				case 'npm':
+					throw new Error(
+						'CKEditor 5 is already loaded from npm. Check the migration guide for more details: ' +
+						createCKDocsUrl( 'updating/migration-to-cdn/vanilla-js.html' )
+					);
+
+				case 'cdn':
+					if ( installationInfo.version !== version ) {
+						throw new Error(
+							`CKEditor 5 version ${ installationInfo.version } is already loaded from CDN. ` +
+							`The requested version is ${ version }.`
+						);
+					}
+
+					break;
+			}
+		}
 	};
 }
 

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -3,13 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '../utils/loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '@/cdn/utils/loadCKCdnResourcesPack';
 import type { CKCdnBaseBundlePackConfig } from './createCKCdnBaseBundlePack';
 
+import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
+import { injectScriptsInParallel } from '@/utils/injectScript';
+import { without } from '@/utils/without';
+
 import { createCKCdnUrl } from './createCKCdnUrl';
-import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
-import { injectScriptsInParallel } from '../../utils/injectScript';
-import { without } from '../../utils/without';
 
 import './globals.d';
 

--- a/src/cdn/ck/createCKCdnUrl.ts
+++ b/src/cdn/ck/createCKCdnUrl.ts
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+import type { SemanticVersion } from '@/utils/isSemanticVersion';
+
 /**
  * The URL of the CKEditor CDN.
  */
@@ -11,7 +13,7 @@ export const CK_CDN_URL = 'https://cdn.ckeditor.com';
 /**
  * A version of a file on the CKEditor CDN.
  */
-export type CKCdnVersion = `${ number }.${ number }.${ number }`;
+export type CKCdnVersion = SemanticVersion;
 
 /**
  * Creates a URL to a file on the CKEditor CDN.

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -53,8 +53,8 @@ export function createCKBoxBundlePack(
 
 			if ( installationInfo && installationInfo.version !== version ) {
 				throw new Error(
-					`The CKBox version ${ installationInfo.version } is already installed. ` +
-					`The requested version is ${ version }.`
+					`CKBox is already loaded from CDN in version ${ installationInfo.version } is already installed. ` +
+					`Remove the old <script> and <link> tags loading CKBox to allow loading the ${ version } version.`
 				);
 			}
 		}

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -3,9 +3,10 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '../utils/loadCKCdnResourcesPack';
+import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
+import { getCKBoxInstallationInfo } from '@/installation-info/getCKBoxInstallationInfo';
 
-import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
+import type { CKCdnResourcesAdvancedPack } from '@/cdn/utils/loadCKCdnResourcesPack';
 import { createCKBoxCdnUrl, type CKBoxCdnVersion } from './createCKBoxCdnUrl';
 
 import './globals.d';
@@ -39,14 +40,24 @@ export function createCKBoxBundlePack(
 
 		// Load optional theme, if provided. It's not required but recommended because it improves the look and feel.
 		...theme && {
-			stylesheets: [
-				createCKBoxCdnUrl( 'ckbox', `styles/themes/${ theme }.css`, version )
-			]
+			stylesheets: [ createCKBoxCdnUrl( 'ckbox', `styles/themes/${ theme }.css`, version ) ]
 		},
 
 		// Pick the exported global variables from the window object.
 		checkPluginLoaded: async () =>
-			waitForWindowEntry( [ 'CKBox' ] )
+			waitForWindowEntry( [ 'CKBox' ] ),
+
+		// Check if the CKBox bundle is already loaded and throw an error if it is.
+		beforeInject: () => {
+			const installationInfo = getCKBoxInstallationInfo();
+
+			if ( installationInfo && installationInfo.version !== version ) {
+				throw new Error(
+					`The CKBox version ${ installationInfo.version } is already installed. ` +
+					`The requested version is ${ version }.`
+				);
+			}
+		}
 	};
 }
 

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -53,7 +53,7 @@ export function createCKBoxBundlePack(
 
 			if ( installationInfo && installationInfo.version !== version ) {
 				throw new Error(
-					`CKBox is already loaded from CDN in version ${ installationInfo.version } is already installed. ` +
+					`CKBox is already loaded from CDN in version ${ installationInfo.version }. ` +
 					`Remove the old <script> and <link> tags loading CKBox to allow loading the ${ version } version.`
 				);
 			}

--- a/src/cdn/ckbox/createCKBoxCdnUrl.ts
+++ b/src/cdn/ckbox/createCKBoxCdnUrl.ts
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+import type { SemanticVersion } from '@/utils/isSemanticVersion';
+
 /**
  * The URL of the CKBox CDN.
  */
@@ -11,7 +13,7 @@ export const CKBOX_CDN_URL = 'https://cdn.ckbox.io';
 /**
  * A version of a file on the CKBox CDN.
  */
-export type CKBoxCdnVersion = `${ number }.${ number }.${ number }`;
+export type CKBoxCdnVersion = SemanticVersion;
 
 /**
  * Creates a URL to a file on the CKBox CDN.

--- a/src/cdn/plugins/combineCdnPluginsPacks.ts
+++ b/src/cdn/plugins/combineCdnPluginsPacks.ts
@@ -3,8 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
-import { mapObjectValues } from '../../utils/mapObjectValues';
-import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
+import { mapObjectValues } from '@/utils/mapObjectValues';
+import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
 
 import {
 	normalizeCKCdnResourcesPack,

--- a/src/cdn/utils/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/utils/combineCKCdnBundlesPacks.ts
@@ -3,8 +3,9 @@
  * For licensing, see LICENSE.md.
  */
 
-import { filterBlankObjectValues } from '../../utils/filterBlankObjectValues';
-import { mapObjectValues } from '../../utils/mapObjectValues';
+import { filterBlankObjectValues } from '@/utils/filterBlankObjectValues';
+import { mapObjectValues } from '@/utils/mapObjectValues';
+
 import {
 	normalizeCKCdnResourcesPack,
 	type CKCdnResourcesPack,
@@ -71,8 +72,16 @@ export function combineCKCdnBundlesPacks<P extends CKCdnBundlesPacks>( packs: P 
 		return exportedGlobalVariables as any;
 	};
 
+	// Call beforeInject method of all packs.
+	const beforeInject = () => {
+		for ( const pack of Object.values( normalizedPacks ) ) {
+			pack.beforeInject?.();
+		}
+	};
+
 	return {
 		...mergedPacks,
+		beforeInject,
 		checkPluginLoaded
 	};
 }

--- a/src/cdn/utils/loadCKCdnResourcesPack.ts
+++ b/src/cdn/utils/loadCKCdnResourcesPack.ts
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { Awaitable } from '../../types/Awaitable';
+import type { Awaitable } from '@/types/Awaitable';
 
-import { injectScript, type InjectScriptProps } from '../../utils/injectScript';
-import { injectStylesheet } from '../../utils/injectStylesheet';
-import { preloadResource } from '../../utils/preloadResource';
-import { uniq } from '../../utils/uniq';
+import { injectScript, type InjectScriptProps } from '@/utils/injectScript';
+import { injectStylesheet } from '@/utils/injectStylesheet';
+import { preloadResource } from '@/utils/preloadResource';
+import { uniq } from '@/utils/uniq';
 
 /**
  * Loads pack of resources (scripts and stylesheets) and returns the exported global variables (if any).
@@ -32,8 +32,12 @@ export async function loadCKCdnResourcesPack<P extends CKCdnResourcesPack<any>>(
 		scripts = [],
 		stylesheets = [],
 		preload,
+		beforeInject,
 		checkPluginLoaded
 	} = normalizeCKCdnResourcesPack( pack );
+
+	// Execute the `beforeInject` callback if defined. It checks if the resources are already loaded.
+	beforeInject?.();
 
 	// If preload is not defined, use all stylesheets and scripts as preload resources.
 	if ( !preload ) {
@@ -173,6 +177,11 @@ export type CKCdnResourcesAdvancedPack<R> = {
 	 * It can be used to specify `crossorigin` or `nonce` attributes on the injected HTML elements.
 	 */
 	htmlAttributes?: Record<string, any>;
+
+	/**
+	 * Callback that is executed before injecting the resources. It can be used to verify if the resources are already loaded.
+	 */
+	beforeInject?: () => void;
 
 	/**
 	 * Get JS object with global variables exported by scripts.

--- a/src/docs/createCKDocsUrl.ts
+++ b/src/docs/createCKDocsUrl.ts
@@ -1,0 +1,15 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { SemanticVersion } from '@/utils/isSemanticVersion';
+
+export const CK_DOCS_URL = 'https://ckeditor.com/docs/ckeditor5';
+
+/**
+ * Creates a URL to a file on the CKEditor documentation.
+ */
+export function createCKDocsUrl( path: string, version: SemanticVersion | 'latest' = 'latest' ): string {
+	return `${ CK_DOCS_URL }/${ version }/${ path }`;
+}

--- a/src/installation-info/getCKBaseBundleInstallationInfo.ts
+++ b/src/installation-info/getCKBaseBundleInstallationInfo.ts
@@ -1,0 +1,25 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { BundleInstallationInfo } from './types';
+
+import { isSemanticVersion } from '@/utils/isSemanticVersion';
+
+/**
+ * Returns information about the base CKEditor bundle installation.
+ */
+export function getCKBaseBundleInstallationInfo(): BundleInstallationInfo | null {
+	const { CKEDITOR_VERSION, CKEDITOR } = window;
+
+	if ( !isSemanticVersion( CKEDITOR_VERSION ) ) {
+		return null;
+	}
+
+	// Global `CKEDITOR` is set only in CDN builds.
+	return {
+		source: CKEDITOR ? 'cdn' : 'npm',
+		version: CKEDITOR_VERSION
+	};
+}

--- a/src/installation-info/getCKBoxInstallationInfo.ts
+++ b/src/installation-info/getCKBoxInstallationInfo.ts
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { BundleInstallationInfo } from './types';
+
+import { isSemanticVersion } from '@/utils/isSemanticVersion';
+
+/**
+ * Returns information about the CKBox installation.
+ */
+export function getCKBoxInstallationInfo(): BundleInstallationInfo | null {
+	const version = window.CKBox?.version;
+
+	if ( !isSemanticVersion( version ) ) {
+		return null;
+	}
+
+	return {
+		source: 'cdn',
+		version
+	};
+}

--- a/src/installation-info/types.ts
+++ b/src/installation-info/types.ts
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { SemanticVersion } from '@/utils/isSemanticVersion';
+
+/**
+ * The source from which CKEditor was installed.
+ */
+type BundleInstallationSource = 'npm' | 'cdn';
+
+/**
+ * Information about the currently installed CKEditor.
+ */
+export type BundleInstallationInfo = {
+
+	/**
+	 * The source from which CKEditor was installed.
+	 */
+	source: BundleInstallationSource;
+
+	/**
+	 * The version of CKEditor.
+	 */
+	version: SemanticVersion;
+};

--- a/src/utils/isSemanticVersion.ts
+++ b/src/utils/isSemanticVersion.ts
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export type SemanticVersion = `${ number }.${ number }.${ number }`;
+
+/**
+ * Checks if the given string is a semantic version number.
+ *
+ * @param version - The string to check.
+ * @returns `true` if the string is a semantic version, `false` otherwise.
+ */
+export function isSemanticVersion( version: string | undefined | null ): version is SemanticVersion {
+	return !!version && /^\d+\.\d+\.\d+/.test( version );
+}

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -91,7 +91,8 @@ describe( 'createCKCdnBaseBundlePack', () => {
 	it( 'should throw an error if the requested version differs from the installed one', async () => {
 		await loadCKEditor( '43.0.0' );
 		await expect( async () => loadCKEditor( '42.0.0' ) ).rejects.toThrowError(
-			'CKEditor 5 version 43.0.0 is already loaded from CDN. The requested version is 42.0.0.'
+			'CKEditor 5 is already loaded from CDN in version 43.0.0. ' +
+			'Remove the old <script> and <link> tags loading CKEditor 5 to allow loading the 4.2.0 version.'
 		);
 	} );
 

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -92,7 +92,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 		await loadCKEditor( '43.0.0' );
 		await expect( async () => loadCKEditor( '42.0.0' ) ).rejects.toThrowError(
 			'CKEditor 5 is already loaded from CDN in version 43.0.0. ' +
-			'Remove the old <script> and <link> tags loading CKEditor 5 to allow loading the 4.2.0 version.'
+			'Remove the old <script> and <link> tags loading CKEditor 5 to allow loading the 42.0.0 version.'
 		);
 	} );
 

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -3,13 +3,24 @@
  * For licensing, see LICENSE.md.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import type { CKCdnVersion } from '@/cdn/ck/createCKCdnUrl';
+
 import {
 	createCKCdnBaseBundlePack,
 	type CKCdnBaseBundlePackConfig
 } from '@/cdn/ck/createCKCdnBaseBundlePack';
 
+import { removeAllCkCdnResources } from '@/tests/_utils';
+import { loadCKCdnResourcesPack } from '@/cdn/utils/loadCKCdnResourcesPack';
+import { createCKDocsUrl } from '@/docs/createCKDocsUrl';
+
 describe( 'createCKCdnBaseBundlePack', () => {
+	beforeEach( () => {
+		removeAllCkCdnResources();
+	} );
+
 	it( 'should create a pack of resources for the base CKEditor bundle', () => {
 		const config: CKCdnBaseBundlePackConfig = {
 			version: '43.0.0',
@@ -76,4 +87,33 @@ describe( 'createCKCdnBaseBundlePack', () => {
 			]
 		} );
 	} );
+
+	it( 'should throw an error if the requested version differs from the installed one', async () => {
+		await loadCKEditor( '43.0.0' );
+		await expect( async () => loadCKEditor( '42.0.0' ) ).rejects.toThrowError(
+			'CKEditor 5 version 43.0.0 is already loaded from CDN. The requested version is 42.0.0.'
+		);
+	} );
+
+	it( 'should not throw an error if the requested version is the same as the installed one', async () => {
+		await loadCKEditor( '43.0.0' );
+		await expect( loadCKEditor( '43.0.0' ) ).resolves.not.toThrow();
+	} );
+
+	it( 'should throw an error if CKEditor 5 is loaded from NPM', async () => {
+		window.CKEDITOR_VERSION = '41.0.0';
+
+		await expect( async () => loadCKEditor( '43.0.0' ) ).rejects.toThrowError(
+			'CKEditor 5 is already loaded from npm. Check the migration guide for more details: ' +
+			createCKDocsUrl( 'updating/migration-to-cdn/vanilla-js.html' )
+		);
+	} );
 } );
+
+function loadCKEditor( version: CKCdnVersion ) {
+	return loadCKCdnResourcesPack(
+		createCKCdnBaseBundlePack( {
+			version
+		} )
+	);
+}

--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -3,10 +3,21 @@
  * For licensing, see LICENSE.md.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import type { CKCdnVersion } from '@/cdn/ck/createCKCdnUrl';
+
+import { loadCKCdnResourcesPack } from '@/cdn/utils/loadCKCdnResourcesPack';
 import { createCKCdnPremiumBundlePack } from '@/cdn/ck/createCKCdnPremiumBundlePack';
+import { createCKCdnBaseBundlePack } from '@/cdn/ck/createCKCdnBaseBundlePack';
+
+import { removeAllCkCdnResources } from '@/tests/_utils';
 
 describe( 'createCKCdnPremiumBundlePack', () => {
+	beforeEach( () => {
+		removeAllCkCdnResources();
+	} );
+
 	it( 'should return a pack of resources for the CKEditor Premium Features', () => {
 		const pack = createCKCdnPremiumBundlePack( {
 			version: '43.0.0',
@@ -69,4 +80,27 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 			]
 		} );
 	} );
+
+	describe( 'error handling', () => {
+		beforeEach( async () => {
+			await loadCKCdnResourcesPack(
+				createCKCdnBaseBundlePack( {
+					version: '43.0.0'
+				} )
+			);
+		} );
+
+		it( 'should not throw an error if the requested version is the same as the installed one', async () => {
+			await loadCKPremiumFeatures( '43.0.0' );
+			await expect( loadCKPremiumFeatures( '43.0.0' ) ).resolves.not.toThrow();
+		} );
+	} );
 } );
+
+function loadCKPremiumFeatures( version: CKCdnVersion ) {
+	return loadCKCdnResourcesPack(
+		createCKCdnPremiumBundlePack( {
+			version
+		} )
+	);
+}

--- a/tests/cdn/ckbox/createCKBoxBundlePack.test.ts
+++ b/tests/cdn/ckbox/createCKBoxBundlePack.test.ts
@@ -3,10 +3,20 @@
  * For licensing, see LICENSE.md.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import type { CKBoxCdnVersion } from '@/cdn/ckbox/createCKBoxCdnUrl';
+
 import { createCKBoxBundlePack } from '@/cdn/ckbox/createCKBoxCdnBundlePack';
+import { loadCKCdnResourcesPack } from '@/cdn/utils/loadCKCdnResourcesPack';
+
+import { removeAllCkCdnResources } from '@/tests/_utils';
 
 describe( 'createCKBoxBundlePack', () => {
+	beforeEach( () => {
+		removeAllCkCdnResources();
+	} );
+
 	it( 'should return a pack of resources for the base CKBox bundle', async () => {
 		const pack = createCKBoxBundlePack( {
 			version: '2.5.1'
@@ -19,7 +29,28 @@ describe( 'createCKBoxBundlePack', () => {
 			stylesheets: [
 				'https://cdn.ckbox.io/ckbox/2.5.1/styles/themes/lark.css'
 			],
+			beforeInject: expect.any( Function ),
 			checkPluginLoaded: expect.any( Function )
 		} );
 	} );
+
+	it( 'should not throw an error if the requested version is the same as the installed one', async () => {
+		await loadCKBox( '2.5.1' );
+		await expect( loadCKBox( '2.5.1' ) ).resolves.not.toThrow();
+	} );
+
+	it( 'should throw an error if the requested version is different than the installed one', async () => {
+		await loadCKBox( '2.5.1' );
+		await expect( async () => loadCKBox( '2.5.0' ) ).rejects.toThrowError(
+			'The CKBox version 2.5.1 is already installed. The requested version is 2.5.0.'
+		);
+	} );
 } );
+
+function loadCKBox( version: CKBoxCdnVersion ) {
+	return loadCKCdnResourcesPack(
+		createCKBoxBundlePack( {
+			version
+		} )
+	);
+}

--- a/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
+++ b/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
@@ -42,7 +42,7 @@ describe( 'createCKBoxCdnBundlePack', () => {
 	it( 'should throw an error if the requested version is different than the installed one', async () => {
 		await loadCKBox( '2.5.1' );
 		await expect( async () => loadCKBox( '2.5.0' ) ).rejects.toThrowError(
-			'CKBox is already loaded from CDN in version 2.5.1 is already installed. ' +
+			'CKBox is already loaded from CDN in version 2.5.1. ' +
 			'Remove the old <script> and <link> tags loading CKBox to allow loading the 2.5.0 version.'
 		);
 	} );

--- a/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
+++ b/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
@@ -12,7 +12,7 @@ import { loadCKCdnResourcesPack } from '@/cdn/utils/loadCKCdnResourcesPack';
 
 import { removeAllCkCdnResources } from '@/tests/_utils';
 
-describe( 'createCKBoxBundlePack', () => {
+describe( 'createCKBoxCdnBundlePack', () => {
 	beforeEach( () => {
 		removeAllCkCdnResources();
 	} );
@@ -42,7 +42,8 @@ describe( 'createCKBoxBundlePack', () => {
 	it( 'should throw an error if the requested version is different than the installed one', async () => {
 		await loadCKBox( '2.5.1' );
 		await expect( async () => loadCKBox( '2.5.0' ) ).rejects.toThrowError(
-			'The CKBox version 2.5.1 is already installed. The requested version is 2.5.0.'
+			'CKBox is already loaded from CDN in version 2.5.1 is already installed. ' +
+			'Remove the old <script> and <link> tags loading CKBox to allow loading the 2.5.0 version.'
 		);
 	} );
 } );

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -15,7 +15,7 @@ import { createCKBoxBundlePack } from '@/cdn/ckbox/createCKBoxCdnBundlePack';
 import { createCKBoxCdnUrl } from '@/cdn/ckbox/createCKBoxCdnUrl';
 
 import { queryPreload, queryScript, queryStylesheet, removeAllCkCdnResources } from '../_utils';
-import { createCKCdnUrl } from '@/src/cdn/ck/createCKCdnUrl';
+import { createCKCdnUrl } from '@/cdn/ck/createCKCdnUrl';
 import {
 	queryAllInjectedLinks,
 	queryAllInjectedScripts

--- a/tests/cdn/plugins/combineCKPluginsPacks.test.ts
+++ b/tests/cdn/plugins/combineCKPluginsPacks.test.ts
@@ -26,6 +26,7 @@ describe( 'combineCdnPluginsPacks', () => {
 		} );
 
 		expect( combinedPack ).toEqual( {
+			beforeInject: expect.any( Function ),
 			scripts: [ 'https://example.org/screen-reader.js' ],
 			preload: [],
 			stylesheets: [],

--- a/tests/cdn/utils/loadCKCdnResourcesPack.test.ts
+++ b/tests/cdn/utils/loadCKCdnResourcesPack.test.ts
@@ -16,6 +16,7 @@ import {
 	CDN_MOCK_SCRIPT_URL,
 	CDN_MOCK_STYLESHEET_URL
 } from 'tests/_utils';
+import { queryAllInjectedScripts } from '@/tests/_utils/queryInjectedElements';
 
 describe( 'loadCKCdnResourcesPack', () => {
 	beforeEach( () => {
@@ -61,6 +62,20 @@ describe( 'loadCKCdnResourcesPack', () => {
 		} );
 
 		expect( result ).toEqual( loaded );
+	} );
+
+	it( 'should execute beforeInject callback before injecting the resources', async () => {
+		const beforeInject = vi.fn().mockImplementation( () => {
+			expect( window.CKEDITOR ).toBeUndefined();
+			expect( queryAllInjectedScripts() ).toHaveLength( 0 );
+		} );
+
+		await loadCKCdnResourcesPack( {
+			scripts: [ CDN_MOCK_SCRIPT_URL ],
+			beforeInject
+		} );
+
+		expect( beforeInject ).toHaveBeenCalled();
 	} );
 
 	it( 'should inject the script if the pack contains one', async () => {

--- a/tests/docs/createCKDocsUrl.test.ts
+++ b/tests/docs/createCKDocsUrl.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createCKDocsUrl } from '@/docs/createCKDocsUrl';
+
+describe( 'createCKDocsUrl', () => {
+	it( 'should create a URL with the latest version by default', () => {
+		const path = 'guide/getting-started';
+		const expectedUrl = 'https://ckeditor.com/docs/ckeditor5/latest/guide/getting-started';
+
+		expect( createCKDocsUrl( path ) ).toBe( expectedUrl );
+	} );
+
+	it( 'should create a URL with a specific version', () => {
+		const path = 'guide/getting-started';
+		const version = '34.0.0';
+		const expectedUrl = `https://ckeditor.com/docs/ckeditor5/${ version }/guide/getting-started`;
+
+		expect( createCKDocsUrl( path, version ) ).toBe( expectedUrl );
+	} );
+
+	it( 'should handle paths with leading slashes', () => {
+		const path = 'getting-started/index.html';
+		const expectedUrl = 'https://ckeditor.com/docs/ckeditor5/latest/getting-started/index.html';
+
+		expect( createCKDocsUrl( path ) ).toBe( expectedUrl );
+	} );
+
+	it( 'should handle paths with trailing slashes', () => {
+		const path = 'guide/getting-started/';
+		const expectedUrl = 'https://ckeditor.com/docs/ckeditor5/latest/guide/getting-started/';
+
+		expect( createCKDocsUrl( path ) ).toBe( expectedUrl );
+	} );
+} );

--- a/tests/installation-info/getCKBaseBundleInstallationInfo.test.ts
+++ b/tests/installation-info/getCKBaseBundleInstallationInfo.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, beforeEach, expect } from 'vitest';
+
+import { getCKBaseBundleInstallationInfo } from '@/installation-info/getCKBaseBundleInstallationInfo';
+import { loadCKEditorCloud } from '@/cdn/loadCKEditorCloud';
+
+import { removeAllCkCdnResources } from '@/tests/_utils';
+
+describe( 'getCKBaseBundleInstallationInfo', () => {
+	beforeEach( () => {
+		removeAllCkCdnResources();
+	} );
+
+	it( 'should return null if the CKEditor bundle is not available', () => {
+		expect( getCKBaseBundleInstallationInfo() ).toBeNull();
+	} );
+
+	it( 'should return null if the `CKEDITOR_VERSION` is not a semantic version', () => {
+		window.CKEDITOR_VERSION = 'foo';
+
+		expect( getCKBaseBundleInstallationInfo() ).toBeNull();
+	} );
+
+	it( 'should return NPM source if the base CKEditor bundle is not injected from the CDN', () => {
+		window.CKEDITOR_VERSION = '43.0.0';
+
+		expect( getCKBaseBundleInstallationInfo() ).toEqual( {
+			source: 'npm',
+			version: '43.0.0'
+		} );
+	} );
+
+	it( 'should return CDN source if the base CKEditor bundle is injected from the CDN', async () => {
+		await loadCKEditorCloud( {
+			version: '43.0.0'
+		} );
+
+		expect( getCKBaseBundleInstallationInfo() ).toEqual( {
+			source: 'cdn',
+			version: '43.0.0'
+		} );
+	} );
+} );

--- a/tests/installation-info/getCKBoxInstallationInfo.test.ts
+++ b/tests/installation-info/getCKBoxInstallationInfo.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, beforeEach, expect } from 'vitest';
+
+import { getCKBoxInstallationInfo } from '@/installation-info/getCKBoxInstallationInfo';
+import { loadCKEditorCloud } from '@/cdn/loadCKEditorCloud';
+
+import { removeAllCkCdnResources } from '@/tests/_utils';
+
+describe( 'getCKBoxInstallationInfo', () => {
+	beforeEach( () => {
+		removeAllCkCdnResources();
+	} );
+
+	it( 'should return null if CKBox bundle is not installed', () => {
+		expect( getCKBoxInstallationInfo() ).toBeNull();
+	} );
+
+	it( 'should return null if the `CKBox.version` is not a semantic version', () => {
+		window.CKBox = { version: 'foo' } as any;
+
+		expect( getCKBoxInstallationInfo() ).toBeNull();
+	} );
+
+	it( 'should return CDN source if the CKBox bundle is installed', async () => {
+		await loadCKEditorCloud( {
+			version: '43.0.0',
+			ckbox: {
+				version: '2.5.1'
+			}
+		} );
+
+		expect( getCKBoxInstallationInfo() ).toEqual( {
+			source: 'cdn',
+			version: '2.5.1'
+		} );
+	} );
+} );

--- a/tests/utils/injectScript.test.ts
+++ b/tests/utils/injectScript.test.ts
@@ -9,7 +9,7 @@ import { CDN_MOCK_SCRIPT_URL, removeCkCdnScripts } from 'tests/_utils/ckCdnMocks
 import { queryScript } from 'tests/_utils';
 
 import { INJECTED_SCRIPTS, injectScript } from '@/utils/injectScript';
-import { createDefer } from '@/src/utils/defer';
+import { createDefer } from '@/utils/defer';
 
 describe( 'injectScript', () => {
 	beforeEach( () => {

--- a/tests/utils/isSemanticVersion.test.ts
+++ b/tests/utils/isSemanticVersion.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isSemanticVersion } from '@/utils/isSemanticVersion';
+
+describe( 'isSemanticVersion', () => {
+	it( 'should return true for a valid semantic version', () => {
+		expect( isSemanticVersion( '1.2.3' ) ).toBe( true );
+		expect( isSemanticVersion( '1.2.3-beta' ) ).toBe( true );
+		expect( isSemanticVersion( '1.2.3-beta.4' ) ).toBe( true );
+		expect( isSemanticVersion( '1.2.3-beta.4+build' ) ).toBe( true );
+		expect( isSemanticVersion( '1.2.3+build' ) ).toBe( true );
+	} );
+
+	it( 'should return false for an invalid semantic version', () => {
+		expect( isSemanticVersion( '.01.0' ) ).toBe( false );
+		expect( isSemanticVersion( 'alpha' ) ).toBe( false );
+		expect( isSemanticVersion( '1.2' ) ).toBe( false );
+		expect( isSemanticVersion( '' ) ).toBe( false );
+		expect( isSemanticVersion( null ) ).toBe( false );
+		expect( isSemanticVersion( undefined ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Improved error readability in `loadCKEditorCloud`. It should now detect existing editor instances and provide migration info from NPM to CDN.
