### PR TITLE
Aligned to `ckeditor5-dev` ESM changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,10 +77,10 @@
     ]
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-bump-year": "^42.0.0",
-    "@ckeditor/ckeditor5-dev-ci": "^42.0.0",
-    "@ckeditor/ckeditor5-dev-release-tools": "^42.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
+    "@ckeditor/ckeditor5-dev-bump-year": "^44.0.0-alpha.0",
+    "@ckeditor/ckeditor5-dev-ci": "^44.0.0-alpha.0",
+    "@ckeditor/ckeditor5-dev-release-tools": "^44.0.0-alpha.0",
+    "@ckeditor/ckeditor5-dev-utils": "^44.0.0-alpha.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@vitest/browser": "^2.0.5",
     "@vitest/coverage-istanbul": "^2.0.5",

--- a/scripts/ci/is-project-ready-to-release.js
+++ b/scripts/ci/is-project-ready-to-release.js
@@ -7,10 +7,8 @@
 
 /* eslint-env node */
 
-'use strict';
-
 import { createRequire } from 'module';
-import releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
+import * as releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
 
 const require = createRequire( import.meta.url );
 const { name: packageName } = require( '../../package.json' );

--- a/scripts/preparepackages.js
+++ b/scripts/preparepackages.js
@@ -9,8 +9,8 @@
 
 import { createRequire } from 'module';
 import { Listr } from 'listr2';
-import releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
-import utils from '@ckeditor/ckeditor5-dev-utils';
+import * as releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
+import * as devUtils from '@ckeditor/ckeditor5-dev-utils';
 import parseArguments from './utils/parsearguments.js';
 import getListrOptions from './utils/getlistroptions.js';
 
@@ -65,7 +65,7 @@ const tasks = new Listr( [
 	{
 		title: 'Running build command.',
 		task: () => {
-			return utils.tools.shExec( 'yarn run build', { async: true, verbosity: 'silent' } );
+			return devUtils.tools.shExec( 'yarn run build', { async: true, verbosity: 'silent' } );
 		}
 	},
 	{

--- a/scripts/publishpackages.js
+++ b/scripts/publishpackages.js
@@ -8,8 +8,7 @@
 /* eslint-env node */
 
 import { Listr } from 'listr2';
-import releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
-import releaseCliUtils from '@ckeditor/ckeditor5-dev-release-tools/lib/utils/cli.js';
+import * as releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
 import parseArguments from './utils/parsearguments.js';
 import getListrOptions from './utils/getlistroptions.js';
 
@@ -89,7 +88,7 @@ const tasks = new Listr( [
 		if ( process.env.CKE5_RELEASE_TOKEN ) {
 			githubToken = process.env.CKE5_RELEASE_TOKEN;
 		} else {
-			githubToken = await releaseCliUtils.provideToken();
+			githubToken = await releaseTools.provideToken();
 		}
 
 		await tasks.run();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Aligned to `ckeditor5-dev` ESM changes.

---

### Additional information

This PR requires https://github.com/ckeditor/ckeditor5-dev/pull/1011 to be released. When it is released, all `ckeditor5-dev-*` packages need to be bumped in this repository.
