### PR TITLE
Polyfill `ckeditor5` and `ckeditor5-premium-features` typings if these packages are not installed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "ckeditor5": ">=42.0.0 || ^0.0.0-nightly",
-    "ckeditor5-premium-features": ">=42.0.0 || ^0.0.0-nightly"
+    "ckeditor5": ">=42.0.0 || ^0.0.0-nightly"
   },
   "type": "module",
   "main": "./dist/index.umd.cjs",

--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -3,14 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '@/cdn/utils/loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../../cdn/utils/loadCKCdnResourcesPack';
 
-import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
-import { injectScriptsInParallel } from '@/utils/injectScript';
-import { without } from '@/utils/without';
+import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
+import { injectScriptsInParallel } from '../../utils/injectScript';
+import { without } from '../../utils/without';
 
-import { getCKBaseBundleInstallationInfo } from '@/installation-info/getCKBaseBundleInstallationInfo';
-import { createCKDocsUrl } from '@/docs/createCKDocsUrl';
+import { getCKBaseBundleInstallationInfo } from '../../installation-info/getCKBaseBundleInstallationInfo';
+import { createCKDocsUrl } from '../../docs/createCKDocsUrl';
 
 import { createCKCdnUrl, type CKCdnVersion } from './createCKCdnUrl';
 

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { CKCdnResourcesAdvancedPack } from '@/cdn/utils/loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../../cdn/utils/loadCKCdnResourcesPack';
 import type { CKCdnBaseBundlePackConfig } from './createCKCdnBaseBundlePack';
 
-import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
-import { injectScriptsInParallel } from '@/utils/injectScript';
-import { without } from '@/utils/without';
+import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
+import { injectScriptsInParallel } from '../../utils/injectScript';
+import { without } from '../../utils/without';
 
 import { createCKCdnUrl } from './createCKCdnUrl';
 

--- a/src/cdn/ck/createCKCdnUrl.ts
+++ b/src/cdn/ck/createCKCdnUrl.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { SemanticVersion } from '@/utils/isSemanticVersion';
+import type { SemanticVersion } from '../../utils/isSemanticVersion';
 
 /**
  * The URL of the CKEditor CDN.

--- a/src/cdn/ck/globals.d.ts
+++ b/src/cdn/ck/globals.d.ts
@@ -3,6 +3,9 @@
  * For licensing, see LICENSE.md.
  */
 
+declare module 'ckeditor5-premium-features' {}
+declare module 'ckeditor5' {}
+
 import type * as CKEditorPremiumFeatures from 'ckeditor5-premium-features';
 import type * as CKEditor from 'ckeditor5';
 

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -3,10 +3,10 @@
  * For licensing, see LICENSE.md.
  */
 
-import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
-import { getCKBoxInstallationInfo } from '@/installation-info/getCKBoxInstallationInfo';
+import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
+import { getCKBoxInstallationInfo } from '../../installation-info/getCKBoxInstallationInfo';
 
-import type { CKCdnResourcesAdvancedPack } from '@/cdn/utils/loadCKCdnResourcesPack';
+import type { CKCdnResourcesAdvancedPack } from '../../cdn/utils/loadCKCdnResourcesPack';
 import { createCKBoxCdnUrl, type CKBoxCdnVersion } from './createCKBoxCdnUrl';
 
 import './globals.d';

--- a/src/cdn/ckbox/createCKBoxCdnUrl.ts
+++ b/src/cdn/ckbox/createCKBoxCdnUrl.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { SemanticVersion } from '@/utils/isSemanticVersion';
+import type { SemanticVersion } from '../../utils/isSemanticVersion';
 
 /**
  * The URL of the CKBox CDN.

--- a/src/cdn/plugins/combineCdnPluginsPacks.ts
+++ b/src/cdn/plugins/combineCdnPluginsPacks.ts
@@ -3,8 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
-import { mapObjectValues } from '@/utils/mapObjectValues';
-import { waitForWindowEntry } from '@/utils/waitForWindowEntry';
+import { mapObjectValues } from '../../utils/mapObjectValues';
+import { waitForWindowEntry } from '../../utils/waitForWindowEntry';
 
 import {
 	normalizeCKCdnResourcesPack,

--- a/src/cdn/utils/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/utils/combineCKCdnBundlesPacks.ts
@@ -3,8 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
-import { filterBlankObjectValues } from '@/utils/filterBlankObjectValues';
-import { mapObjectValues } from '@/utils/mapObjectValues';
+import { filterBlankObjectValues } from '../../utils/filterBlankObjectValues';
+import { mapObjectValues } from '../../utils/mapObjectValues';
 
 import {
 	normalizeCKCdnResourcesPack,

--- a/src/cdn/utils/loadCKCdnResourcesPack.ts
+++ b/src/cdn/utils/loadCKCdnResourcesPack.ts
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { Awaitable } from '@/types/Awaitable';
+import type { Awaitable } from '../../types/Awaitable';
 
-import { injectScript, type InjectScriptProps } from '@/utils/injectScript';
-import { injectStylesheet } from '@/utils/injectStylesheet';
-import { preloadResource } from '@/utils/preloadResource';
-import { uniq } from '@/utils/uniq';
+import { injectScript, type InjectScriptProps } from '../../utils/injectScript';
+import { injectStylesheet } from '../../utils/injectStylesheet';
+import { preloadResource } from '../../utils/preloadResource';
+import { uniq } from '../../utils/uniq';
 
 /**
  * Loads pack of resources (scripts and stylesheets) and returns the exported global variables (if any).

--- a/src/docs/createCKDocsUrl.ts
+++ b/src/docs/createCKDocsUrl.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { SemanticVersion } from '@/utils/isSemanticVersion';
+import type { SemanticVersion } from '../utils/isSemanticVersion';
 
 export const CK_DOCS_URL = 'https://ckeditor.com/docs/ckeditor5';
 

--- a/src/installation-info/getCKBaseBundleInstallationInfo.ts
+++ b/src/installation-info/getCKBaseBundleInstallationInfo.ts
@@ -5,7 +5,7 @@
 
 import type { BundleInstallationInfo } from './types';
 
-import { isSemanticVersion } from '@/utils/isSemanticVersion';
+import { isSemanticVersion } from '../utils/isSemanticVersion';
 
 /**
  * Returns information about the base CKEditor bundle installation.

--- a/src/installation-info/getCKBoxInstallationInfo.ts
+++ b/src/installation-info/getCKBoxInstallationInfo.ts
@@ -5,7 +5,7 @@
 
 import type { BundleInstallationInfo } from './types';
 
-import { isSemanticVersion } from '@/utils/isSemanticVersion';
+import { isSemanticVersion } from '../utils/isSemanticVersion';
 
 /**
  * Returns information about the CKBox installation.

--- a/src/installation-info/types.ts
+++ b/src/installation-info/types.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import type { SemanticVersion } from '@/utils/isSemanticVersion';
+import type { SemanticVersion } from '../utils/isSemanticVersion';
 
 /**
  * The source from which CKEditor was installed.

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,7 +2,10 @@
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"baseUrl": "../",
-		"rootDir": "../"
+		"rootDir": "../",
+		"paths": {
+			"@/*": ["./*", "./src/*"]
+		}
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["node_modules/"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,10 +17,7 @@
 		"noEmitOnError": true,
 		"noImplicitAny": true,
 		"allowJs": true,
-		"skipLibCheck": true,
-		"paths": {
-			"@/*": ["./*", "./src/*"]
-		}
+		"skipLibCheck": true
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts"],
 	"exclude": ["node_modules/"]

--- a/vite.test-utils.config.ts
+++ b/vite.test-utils.config.ts
@@ -26,7 +26,12 @@ export default defineConfig( {
 			include: [ 'tests/_utils/**/*', 'src/**/*' ],
 			exclude: [ '**/*.test.ts', '**/*.test.tsx' ],
 			copyDtsFiles: true,
-			clearPureImport: false
+			clearPureImport: false,
+			compilerOptions: {
+				paths: {
+					'@/*': [ './*', './src/*' ]
+				}
+			}
 		} )
 	]
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Polyfill `ckeditor5` and `ckeditor5-premium-features` typings if these packages are not installed.
Fix: No longer use aliases in `src/` files due to incorrect `.d.ts` output. 

---

### Additional information

It fixes this issue:
https://github.com/ckeditor/ckeditor5-angular/issues/447

Some package managers do not install `ckeditor5-premium-features` peer dependency, which cause `tsc` to fail if `skipLibCheck: false` is set in `tsconfig.json`
