### PR TITLE
Add option to override CDN link configuration

### DIFF
--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -35,23 +35,24 @@ import './globals.js';
 export function createCKCdnBaseBundlePack(
 	{
 		version,
-		translations
+		translations,
+		createCustomCdnUrl = createCKCdnUrl
 	}: CKCdnBaseBundlePackConfig
 ): CKCdnResourcesAdvancedPack<Window['CKEDITOR']> {
 	const urls = {
 		scripts: [
 			// Load the main script of the base features.
-			createCKCdnUrl( 'ckeditor5', 'ckeditor5.umd.js', version ),
+			createCustomCdnUrl( 'ckeditor5', 'ckeditor5.umd.js', version ),
 
 			// Load all JavaScript files from the base features.
 			// EN bundle is prebuilt into the main script, so we don't need to load it separately.
 			...without( [ 'en' ], translations || [] ).map( translation =>
-				createCKCdnUrl( 'ckeditor5', `translations/${ translation }.umd.js`, version )
+				createCustomCdnUrl( 'ckeditor5', `translations/${ translation }.umd.js`, version )
 			)
 		],
 
 		stylesheets: [
-			createCKCdnUrl( 'ckeditor5', 'ckeditor5.css', version )
+			createCustomCdnUrl( 'ckeditor5', 'ckeditor5.css', version )
 		]
 	};
 
@@ -113,4 +114,9 @@ export type CKCdnBaseBundlePackConfig = {
 	 * The list of translations to load.
 	 */
 	translations?: Array<string>;
+
+	/**
+	 * The function that creates custom CDN URLs.
+	 */
+	createCustomCdnUrl?: typeof createCKCdnUrl;
 };

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -31,23 +31,24 @@ import { createCKCdnUrl } from './createCKCdnUrl.js';
 export function createCKCdnPremiumBundlePack(
 	{
 		version,
-		translations
+		translations,
+		createCustomCdnUrl = createCKCdnUrl
 	}: CKCdnPremiumBundlePackConfig
 ): CKCdnResourcesAdvancedPack<Window['CKEDITOR_PREMIUM_FEATURES']> {
 	const urls = {
 		scripts: [
 			// Load the main script of the premium features.
-			createCKCdnUrl( 'ckeditor5-premium-features', 'ckeditor5-premium-features.umd.js', version ),
+			createCustomCdnUrl( 'ckeditor5-premium-features', 'ckeditor5-premium-features.umd.js', version ),
 
 			// Load all JavaScript files from the premium features.
 			// EN bundle is prebuilt into the main script, so we don't need to load it separately.
 			...without( [ 'en' ], translations || [] ).map( translation =>
-				createCKCdnUrl( 'ckeditor5-premium-features', `translations/${ translation }.umd.js`, version )
+				createCustomCdnUrl( 'ckeditor5-premium-features', `translations/${ translation }.umd.js`, version )
 			)
 		],
 
 		stylesheets: [
-			createCKCdnUrl( 'ckeditor5-premium-features', 'ckeditor5-premium-features.css', version )
+			createCustomCdnUrl( 'ckeditor5-premium-features', 'ckeditor5-premium-features.css', version )
 		]
 	};
 
@@ -77,5 +78,5 @@ export function createCKCdnPremiumBundlePack(
  */
 export type CKCdnPremiumBundlePackConfig = Pick<
 	CKCdnBaseBundlePackConfig,
-	'translations' | 'version'
+	'translations' | 'version' | 'createCustomCdnUrl'
 >;

--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -29,18 +29,21 @@ import './globals.js';
 export function createCKBoxBundlePack(
 	{
 		version,
-		theme = 'lark'
+		theme = 'lark',
+		createCustomCdnUrl = createCKBoxCdnUrl
 	}: CKBoxCdnBundlePackConfig
 ): CKCdnResourcesAdvancedPack<Window['CKBox']> {
 	return {
 		// Load the main script of the base features.
 		scripts: [
-			createCKBoxCdnUrl( 'ckbox', 'ckbox.js', version )
+			createCustomCdnUrl( 'ckbox', 'ckbox.js', version )
 		],
 
 		// Load optional theme, if provided. It's not required but recommended because it improves the look and feel.
 		...theme && {
-			stylesheets: [ createCKBoxCdnUrl( 'ckbox', `styles/themes/${ theme }.css`, version ) ]
+			stylesheets: [
+				createCustomCdnUrl( 'ckbox', `styles/themes/${ theme }.css`, version )
+			]
 		},
 
 		// Pick the exported global variables from the window object.
@@ -75,4 +78,9 @@ export type CKBoxCdnBundlePackConfig = {
 	 * The theme of the CKBox bundle. Default is 'lark'.
 	 */
 	theme?: string | null;
+
+	/**
+	 * Function that creates a custom URL for the CKBox bundle.
+	 */
+	createCustomCdnUrl?: typeof createCKBoxCdnUrl;
 };

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -13,7 +13,7 @@ import {
 } from './ckbox/createCKBoxCdnBundlePack.js';
 
 import type { ConditionalBlank } from '../types/ConditionalBlank.js';
-import type { CKCdnVersion } from './ck/createCKCdnUrl.js';
+import type { CKCdnVersion, createCKCdnUrl } from './ck/createCKCdnUrl.js';
 
 import {
 	loadCKCdnResourcesPack,
@@ -77,7 +77,7 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 ): Promise<CKEditorCloudResult<Config>> {
 	const {
 		version, translations, plugins,
-		premium, ckbox,
+		premium, ckbox, createCustomCdnUrl,
 		injectedHtmlElementsAttributes = {
 			crossorigin: 'anonymous'
 		}
@@ -86,13 +86,15 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 	const pack = combineCKCdnBundlesPacks( {
 		CKEditor: createCKCdnBaseBundlePack( {
 			version,
-			translations
+			translations,
+			createCustomCdnUrl
 		} ),
 
 		...premium && {
 			CKEditorPremiumFeatures: createCKCdnPremiumBundlePack( {
 				version,
-				translations
+				translations,
+				createCustomCdnUrl
 			} )
 		},
 
@@ -181,4 +183,9 @@ export type CKEditorCloudConfig<Plugins extends CdnPluginsPacks = CdnPluginsPack
 	 * Map of attributes to add to the script, stylesheet and link tags that are injected by the loader.
 	 */
 	injectedHtmlElementsAttributes?: Record<string, any>;
+
+	/**
+	 * The function that creates custom CDN URLs.
+	 */
+	createCustomCdnUrl?: typeof createCKCdnUrl;
 };

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -88,6 +88,27 @@ describe( 'createCKCdnBaseBundlePack', () => {
 		} );
 	} );
 
+	it( 'should allow to specify custom CDN urls using `createCustomCdnUrl` parameter', () => {
+		const pack = createCKCdnBaseBundlePack( {
+			version: '43.0.0',
+			createCustomCdnUrl: ( type, name, version ) => `https://cdn.example.com/${ type }/${ name }/${ version }`
+		} );
+
+		expect( pack ).to.toMatchObject( {
+			checkPluginLoaded: expect.any( Function ),
+			stylesheets: [
+				'https://cdn.example.com/ckeditor5/ckeditor5.css/43.0.0'
+			],
+			scripts: [
+				expect.any( Function )
+			],
+			preload: [
+				'https://cdn.example.com/ckeditor5/ckeditor5.css/43.0.0',
+				'https://cdn.example.com/ckeditor5/ckeditor5.umd.js/43.0.0'
+			]
+		} );
+	} );
+
 	it( 'should throw an error if the requested version differs from the installed one', async () => {
 		await loadCKEditor( '43.0.0' );
 		await expect( async () => loadCKEditor( '42.0.0' ) ).rejects.toThrowError(

--- a/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnPremiumBundlePack.test.ts
@@ -61,6 +61,27 @@ describe( 'createCKCdnPremiumBundlePack', () => {
 		} );
 	} );
 
+	it( 'should allow to specify custom CDN urls using `createCustomCdnUrl` parameter', () => {
+		const pack = createCKCdnPremiumBundlePack( {
+			version: '43.0.0',
+			createCustomCdnUrl: ( type, path, version ) => `https://example.com/${ type }/${ path }/${ version }`
+		} );
+
+		expect( pack ).to.toMatchObject( {
+			checkPluginLoaded: expect.any( Function ),
+			stylesheets: [
+				'https://example.com/ckeditor5-premium-features/ckeditor5-premium-features.css/43.0.0'
+			],
+			scripts: [
+				expect.any( Function )
+			],
+			preload: [
+				'https://example.com/ckeditor5-premium-features/ckeditor5-premium-features.css/43.0.0',
+				'https://example.com/ckeditor5-premium-features/ckeditor5-premium-features.umd.js/43.0.0'
+			]
+		} );
+	} );
+
 	it( 'should not load any language if not provided', () => {
 		const pack = createCKCdnPremiumBundlePack( {
 			version: '43.0.0'

--- a/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
+++ b/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
@@ -45,6 +45,24 @@ describe( 'createCKBoxCdnBundlePack', () => {
 			'Remove the old <script> and <link> tags loading CKBox to allow loading the 2.5.0 version.'
 		);
 	} );
+
+	it( 'should allow to specify custom CDN urls using `createCustomCdnUrl` parameter', () => {
+		const pack = createCKBoxBundlePack( {
+			version: '2.5.1',
+			createCustomCdnUrl: ( type, name, version ) => `https://cdn.example.com/${ type }/${ name }/${ version }`
+		} );
+
+		expect( pack ).toMatchObject( {
+			scripts: [
+				'https://cdn.example.com/ckbox/ckbox.js/2.5.1'
+			],
+			stylesheets: [
+				'https://cdn.example.com/ckbox/styles/themes/lark.css/2.5.1'
+			],
+			beforeInject: expect.any( Function ),
+			checkPluginLoaded: expect.any( Function )
+		} );
+	} );
 } );
 
 function loadCKBox( version: CKBoxCdnVersion ) {

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -84,6 +84,24 @@ describe( 'loadCKEditorCloud', () => {
 		expect( loadedPlugins?.Plugin ).toBeDefined();
 	} );
 
+	it( 'should allow to specify custom CDN urls using `createCustomCdnUrl` parameter', async () => {
+		const { CKEditor } = await loadCKEditorCloud( {
+			version: '43.0.0',
+			premium: true,
+			createCustomCdnUrl: ( type, name, version ) => `${ createCKCdnUrl( type, name, version ) }?testParam=123`
+		} );
+
+		expect( CKEditor.ClassicEditor ).toBeDefined();
+
+		expectBundleLoaded( 'ckeditor5' );
+		expectBundleLoaded( 'ckeditor5-premium-features' );
+
+		function expectBundleLoaded( bundleName: string ) {
+			expect( queryScript( `${ createCKCdnUrl( bundleName, `${ bundleName }.umd.js`, '43.0.0' ) }?testParam=123` ) ).not.toBeNull();
+			expect( queryStylesheet( `${ createCKCdnUrl( bundleName, `${ bundleName }.css`, '43.0.0' ) }?testParam=123` ) ).not.toBeNull();
+		}
+	} );
+
 	describe( 'CSP', () => {
 		it( 'should set crossorigin=anonymous attribute on injected elements if attributes are not specified', async () => {
 			expect( queryAnonymousLinks() ).toHaveLength( 0 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add `createCustomCdnUrl` configuration option that allows to override default CKEditor5 Cloud CDN urls. 
