### PR TITLE
Add support for CKBox translations in CDN injector.

### DIFF
--- a/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
+++ b/src/cdn/ckbox/createCKBoxCdnBundlePack.ts
@@ -4,6 +4,7 @@
  */
 
 import { waitForWindowEntry } from '../../utils/waitForWindowEntry.js';
+import { without } from '../../utils/without.js';
 import { getCKBoxInstallationInfo } from '../../installation-info/getCKBoxInstallationInfo.js';
 
 import type { CKCdnResourcesAdvancedPack } from '../../cdn/utils/loadCKCdnResourcesPack.js';
@@ -30,13 +31,19 @@ export function createCKBoxBundlePack(
 	{
 		version,
 		theme = 'lark',
+		translations,
 		createCustomCdnUrl = createCKBoxCdnUrl
 	}: CKBoxCdnBundlePackConfig
 ): CKCdnResourcesAdvancedPack<Window['CKBox']> {
 	return {
 		// Load the main script of the base features.
 		scripts: [
-			createCustomCdnUrl( 'ckbox', 'ckbox.js', version )
+			createCustomCdnUrl( 'ckbox', 'ckbox.js', version ),
+
+			// EN bundle is prebuilt into the main script, so we don't need to load it separately.
+			...without( [ 'en' ], translations || [] ).map( translation =>
+				createCustomCdnUrl( 'ckbox', `translations/${ translation }.js`, version )
+			)
 		],
 
 		// Load optional theme, if provided. It's not required but recommended because it improves the look and feel.
@@ -73,6 +80,11 @@ export type CKBoxCdnBundlePackConfig = {
 	 * The version of  the base CKEditor bundle.
 	 */
 	version: CKBoxCdnVersion;
+
+	/**
+	 * The list of translations to load.
+	 */
+	translations?: Array<string>;
 
 	/**
 	 * The theme of the CKBox bundle. Default is 'lark'.

--- a/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
+++ b/tests/cdn/ckbox/createCKBoxCdnBundlePack.test.ts
@@ -33,6 +33,26 @@ describe( 'createCKBoxCdnBundlePack', () => {
 		} );
 	} );
 
+	it( 'should return translations scripts if translations are provided', async () => {
+		const pack = createCKBoxBundlePack( {
+			version: '2.5.1',
+			translations: [ 'es', 'de', 'en' ] // EN should be ignored, as it's prebuilt into the main script.
+		} );
+
+		expect( pack ).toMatchObject( {
+			scripts: [
+				'https://cdn.ckbox.io/ckbox/2.5.1/ckbox.js',
+				'https://cdn.ckbox.io/ckbox/2.5.1/translations/es.js',
+				'https://cdn.ckbox.io/ckbox/2.5.1/translations/de.js'
+			],
+			stylesheets: [
+				'https://cdn.ckbox.io/ckbox/2.5.1/styles/themes/lark.css'
+			],
+			beforeInject: expect.any( Function ),
+			checkPluginLoaded: expect.any( Function )
+		} );
+	} );
+
 	it( 'should not throw an error if the requested version is the same as the installed one', async () => {
 		await loadCKBox( '2.5.1' );
 		await expect( loadCKBox( '2.5.1' ) ).resolves.not.toThrow();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add support for CKBox translations in CDN injector.

---

### Additional information

We forgot to add support for internationalization in `CKBox` bundle CDN loader.  It's specified in docs: https://ckeditor.com/docs/ckbox/latest/guides/configuration/localization.html. I added an optional `translations` property to allow users to specify languages to load. 