### PR TITLE
Release `v2.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Changelog
 
 ### Features
 
-* Add `createCustomCdnUrl` configuration option that allows to override default CKEditor5 Cloud CDN urls. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/f13ee317b8ee65a79525824d04ebeeb27b52700b))
-* Improve detection of already installed version of editor. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/adc3143d032a2501c0a5872cb92a36938d720f5a))
+* Added the `createCustomCdnUrl` configuration option to override default CKEditor 5 Cloud CDN URLs in `loadCKEditorCloud`. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/f13ee317b8ee65a79525824d04ebeeb27b52700b))
+* Added support for passing a translations list for CKBox in the configuration for `loadCKEditorCloud`. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/29f8aaf3a82904fc1598a4f81d3803e587d639e2))
+* Improved detection of already installed versions of the editor. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/adc3143d032a2501c0a5872cb92a36938d720f5a))
 
 
 ## [2.1.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v2.0.0...v2.1.0) (2024-09-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## [2.2.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v2.1.0...v2.2.0) (2024-10-29)
+
+### Features
+
+* Add `createCustomCdnUrl` configuration option that allows to override default CKEditor5 Cloud CDN urls. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/f13ee317b8ee65a79525824d04ebeeb27b52700b))
+* Improve detection of already installed version of editor. ([commit](https://github.com/ckeditor/ckeditor5-integrations-common/commit/adc3143d032a2501c0a5872cb92a36938d720f5a))
+
+
 ## [2.1.0](https://github.com/ckeditor/ckeditor5-integrations-common/compare/v2.0.0...v2.1.0) (2024-09-26)
 
 ### Features


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

1. Added the `createCustomCdnUrl` configuration option to override default CKEditor 5 Cloud CDN URLs in `loadCKEditorCloud`.
2. Added support for passing a translations list for `CKBox` in the configuration for `loadCKEditorCloud`.
3. Improved detection of already installed versions of the editor. 

Please read more about these changes in our post [here](https://github.com/ckeditor/ckeditor5/issues/17317).
