### PR TITLE
Add supported editor version check to CDN loader.

### DIFF
--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -27,7 +27,7 @@ import './globals.js';
  * ```ts
  * const { Paragraph } = await loadCKCdnResourcesPack(
  * 	createCKCdnBaseBundlePack( {
- * 		version: '43.0.0',
+ * 		version: '44.0.0',
  * 		translations: [ 'es', 'de' ]
  * 	} )
  * );

--- a/src/cdn/ck/createCKCdnPremiumBundlePack.ts
+++ b/src/cdn/ck/createCKCdnPremiumBundlePack.ts
@@ -22,7 +22,7 @@ import { createCKCdnUrl } from './createCKCdnUrl.js';
  * ```ts
  * const { SlashCommand } = await loadCKCdnResourcesPack(
  * 	createCKCdnPremiumBundlePack( {
- * 		version: '43.0.0',
+ * 		version: '44.0.0',
  * 		translations: [ 'es', 'de' ]
  * 	} )
  * );

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -119,7 +119,7 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 }
 
 /**
- * Checks if the given version the CKEditor 5 version is supported by the CKEditor Cloud Services.
+ * Checks if the given version the CKEditor 5 version is supported by the CKEditor CDN
  * If it is not supported, an error is thrown.
  *
  * @param version The CKEditor version to validate.
@@ -140,7 +140,7 @@ function validateCKEditorVersion( version: CKCdnVersion ) {
 }
 
 /**
- * The result of the resolved bundles from CKEditor Cloud Services.
+ * The result of the resolved bundles from CKEditor CDN.
  */
 export type CKEditorCloudResult<Config extends CKEditorCloudConfig> = {
 

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -119,8 +119,7 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 }
 
 /**
- * Checks if the given version the CKEditor 5 version is supported by the CKEditor CDN
- * If it is not supported, an error is thrown.
+ * Checks if the CKEditor Cloud Services support the given CKEditor 5 version.
  *
  * @param version The CKEditor version to validate.
  */

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -134,7 +134,7 @@ function validateCKEditorVersion( version: CKCdnVersion ) {
 	if ( !isCKCdnSupportedByEditorVersion( version ) ) {
 		throw new Error(
 			`The CKEditor 5 CDN can't be used with the given editor version: ${ version }. ` +
-			'Please make sure you are using at least the CKEditor 5 version 43.'
+			'Please make sure you are using at least the CKEditor 5 version 44.'
 		);
 	}
 }

--- a/src/cdn/loadCKEditorCloud.ts
+++ b/src/cdn/loadCKEditorCloud.ts
@@ -15,6 +15,7 @@ import {
 import type { CKCdnUrlCreator } from './ck/createCKCdnUrl.js';
 import type { ConditionalBlank } from '../types/ConditionalBlank.js';
 
+import { isCKCdnSupportedByEditorVersion } from '../license/isCKCdnSupportedByEditorVersion.js';
 import { isCKCdnTestingVersion, type CKCdnVersion } from './ck/isCKCdnVersion.js';
 
 import {
@@ -40,7 +41,7 @@ import {
  *
  * ```ts
  * const { CKEditor, CKEditorPremiumFeatures } = await loadCKEditorCloud( {
- * 	version: '43.0.0',
+ * 	version: '44.0.0',
  * 	translations: [ 'es', 'de' ],
  * 	premium: true
  * } );
@@ -53,7 +54,7 @@ import {
  *
  * ```ts
  * const { CKEditor, loadedPlugins } = await loadCKEditorCloud( {
- * 	version: '43.0.0',
+ * 	version: '44.0.0',
  * 	plugins: {
  * 		Plugin1: async () => import( './your-local-import.umd.js' ),
  * 		Plugin2: [
@@ -85,11 +86,7 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 		}
 	} = config;
 
-	if ( isCKCdnTestingVersion( version ) ) {
-		console.warn(
-			'You are using a testing version of CKEditor 5. Please remember that it is not suitable for production environments.'
-		);
-	}
+	validateCKEditorVersion( version );
 
 	const pack = combineCKCdnBundlesPacks( {
 		CKEditor: createCKCdnBaseBundlePack( {
@@ -119,6 +116,27 @@ export function loadCKEditorCloud<Config extends CKEditorCloudConfig>(
 			htmlAttributes: injectedHtmlElementsAttributes
 		}
 	) as Promise<CKEditorCloudResult<Config>>;
+}
+
+/**
+ * Checks if the given version the CKEditor 5 version is supported by the CKEditor Cloud Services.
+ * If it is not supported, an error is thrown.
+ *
+ * @param version The CKEditor version to validate.
+ */
+function validateCKEditorVersion( version: CKCdnVersion ) {
+	if ( isCKCdnTestingVersion( version ) ) {
+		console.warn(
+			'You are using a testing version of CKEditor 5. Please remember that it is not suitable for production environments.'
+		);
+	}
+
+	if ( !isCKCdnSupportedByEditorVersion( version ) ) {
+		throw new Error(
+			`The CKEditor 5 CDN can't be used with the given editor version: ${ version }. ` +
+			'Please make sure you are using at least the CKEditor 5 version 43.'
+		);
+	}
 }
 
 /**

--- a/src/cdn/utils/combineCKCdnBundlesPacks.ts
+++ b/src/cdn/utils/combineCKCdnBundlesPacks.ts
@@ -24,11 +24,11 @@ import {
  * const { Base, Premium } = await loadCKCdnResourcesPack(
  * 	combineCKCdnBundlesPacks( {
  * 		Base: createCKCdnBaseBundlePack( {
- * 			version: '43.0.0',
+ * 			version: '44.0.0',
  * 			translations: [ 'es', 'de' ]
  * 		} ),
  * 		Premium: createCKCdnPremiumBundlePack( {
- * 			version: '43.0.0',
+ * 			version: '44.0.0',
  * 			translations: [ 'es', 'de' ]
  * 		} )
  * 	} )

--- a/src/installation-info/getSupportedLicenseVersionInstallationInfo.ts
+++ b/src/installation-info/getSupportedLicenseVersionInstallationInfo.ts
@@ -3,10 +3,9 @@
  * For licensing, see LICENSE.md.
  */
 
-import { isCKCdnTestingVersion } from '../cdn/ck/isCKCdnVersion.js';
+import { getLicenseVersionFromEditorVersion } from '../license/getLicenseVersionFromEditorVersion.js';
 import type { LicenseKeyVersion } from '../license/LicenseKey.js';
 
-import { destructureSemanticVersion } from '../utils/version/destructureSemanticVersion.js';
 import { getCKBaseBundleInstallationInfo } from './getCKBaseBundleInstallationInfo.js';
 
 /**
@@ -22,26 +21,5 @@ export function getSupportedLicenseVersionInstallationInfo(): LicenseKeyVersion 
 		return null;
 	}
 
-	const { version } = installationInfo;
-
-	// Assume that the testing version is always the newest one
-	// so we can return the highest supported license version.
-	if ( isCKCdnTestingVersion( version ) ) {
-		return 3;
-	}
-
-	const { major } = destructureSemanticVersion( version );
-
-	// License V3 was released in CKEditor 44.0.0.
-	if ( major >= 44 ) {
-		return 3;
-	}
-
-	// License V2 was released in CKEditor 38.0.0.
-	if ( major >= 38 ) {
-		return 2;
-	}
-
-	// License V1.
-	return 1;
+	return getLicenseVersionFromEditorVersion( installationInfo.version );
 }

--- a/src/license/getLicenseVersionFromEditorVersion.ts
+++ b/src/license/getLicenseVersionFromEditorVersion.ts
@@ -1,0 +1,35 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { type CKCdnVersion, isCKCdnTestingVersion } from '../cdn/ck/isCKCdnVersion.js';
+import { destructureSemanticVersion } from '../utils/version/destructureSemanticVersion.js';
+import type { LicenseKeyVersion } from './LicenseKey.js';
+
+/**
+ * Returns the license version that is supported by the given CKEditor version.
+ *
+ * @param version The CKEditor version (semantic version or testing version).
+ * @returns The supported license version.
+ */
+export function getLicenseVersionFromEditorVersion( version: CKCdnVersion ): LicenseKeyVersion {
+	// Assume that the testing version is always the newest one
+	// so we can return the highest supported license version.
+	if ( isCKCdnTestingVersion( version ) ) {
+		return 3;
+	}
+
+	const { major } = destructureSemanticVersion( version );
+
+	switch ( true ) {
+		case major >= 44:
+			return 3;
+
+		case major >= 38:
+			return 2;
+
+		default:
+			return 1;
+	}
+}

--- a/src/license/isCKCdnSupportedByEditorVersion.ts
+++ b/src/license/isCKCdnSupportedByEditorVersion.ts
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { destructureSemanticVersion } from 'utils/version/destructureSemanticVersion.js';
+import { isCKCdnTestingVersion, type CKCdnVersion } from '../cdn/ck/isCKCdnVersion.js';
+import { getLicenseVersionFromEditorVersion } from './getLicenseVersionFromEditorVersion.js';
+
+/**
+ * Checks if the CKEditor CDN is supported by the given editor version.
+ *
+ * @param version The CKEditor version.
+ * @returns `true` if the CDN is supported, `false` otherwise.
+ */
+export function isCKCdnSupportedByEditorVersion( version: CKCdnVersion ): boolean {
+	if ( isCKCdnTestingVersion( version ) ) {
+		return true;
+	}
+
+	const { major } = destructureSemanticVersion( version );
+	const licenseVersion = getLicenseVersionFromEditorVersion( version );
+
+	switch ( licenseVersion ) {
+		// For newer license versions, we support all newer versions.
+		case 3:
+			return true;
+
+		// For the license v1-v2, we support only the 43 version.
+		default:
+			return major === 43;
+	}
+}

--- a/src/license/isCKCdnSupportedByEditorVersion.ts
+++ b/src/license/isCKCdnSupportedByEditorVersion.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import { destructureSemanticVersion } from 'utils/version/destructureSemanticVersion.js';
+import { destructureSemanticVersion } from '../utils/version/destructureSemanticVersion.js';
 import { isCKCdnTestingVersion, type CKCdnVersion } from '../cdn/ck/isCKCdnVersion.js';
 import { getLicenseVersionFromEditorVersion } from './getLicenseVersionFromEditorVersion.js';
 

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -52,7 +52,7 @@ describe( 'loadCKEditorCloud', () => {
 	it( 'should raise exception if unsupported version is passed', () => {
 		expect( () => loadCKEditorCloud( { version: '42.0.0' } ) ).toThrowError(
 			'The CKEditor 5 CDN can\'t be used with the given editor version: 42.0.0. ' +
-			'Please make sure you are using at least the CKEditor 5 version 43.'
+			'Please make sure you are using at least the CKEditor 5 version 44.'
 		);
 	} );
 

--- a/tests/cdn/loadCKEditorCloud.test.ts
+++ b/tests/cdn/loadCKEditorCloud.test.ts
@@ -49,6 +49,13 @@ describe( 'loadCKEditorCloud', () => {
 		} );
 	}
 
+	it( 'should raise exception if unsupported version is passed', () => {
+		expect( () => loadCKEditorCloud( { version: '42.0.0' } ) ).toThrowError(
+			'The CKEditor 5 CDN can\'t be used with the given editor version: 42.0.0. ' +
+			'Please make sure you are using at least the CKEditor 5 version 43.'
+		);
+	} );
+
 	it( 'should not raise a warning if non-testing version is passed', async () => {
 		const { CKEditor } = await loadCKEditorCloud( {
 			version: '43.0.0'

--- a/tests/license/isCKCdnSupportedByEditorVersion.test.ts
+++ b/tests/license/isCKCdnSupportedByEditorVersion.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isCKCdnSupportedByEditorVersion } from '@/license/isCKCdnSupportedByEditorVersion.js';
+
+describe( 'isCKCdnSupportedByEditorVersion', () => {
+	it( 'should return true for testing versions', () => {
+		expect( isCKCdnSupportedByEditorVersion( 'alpha' ) ).toBe( true );
+		expect( isCKCdnSupportedByEditorVersion( 'nightly' ) ).toBe( true );
+	} );
+
+	it( 'should return true for version 44.x.x (license v3)', () => {
+		expect( isCKCdnSupportedByEditorVersion( '44.0.0' ) ).toBe( true );
+		expect( isCKCdnSupportedByEditorVersion( '44.1.0' ) ).toBe( true );
+		expect( isCKCdnSupportedByEditorVersion( '44.1.1' ) ).toBe( true );
+	} );
+
+	it( 'should return true for version 43.x.x (license v1-v2)', () => {
+		expect( isCKCdnSupportedByEditorVersion( '43.0.0' ) ).toBe( true );
+		expect( isCKCdnSupportedByEditorVersion( '43.1.0' ) ).toBe( true );
+		expect( isCKCdnSupportedByEditorVersion( '43.2.1' ) ).toBe( true );
+	} );
+
+	it( 'should return false for versions below 43.x.x', () => {
+		expect( isCKCdnSupportedByEditorVersion( '42.0.0' ) ).toBe( false );
+		expect( isCKCdnSupportedByEditorVersion( '41.1.0' ) ).toBe( false );
+		expect( isCKCdnSupportedByEditorVersion( '40.0.0' ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Check minimum supported editor version before injecting cloud files. 

---

### Additional information

No longer raise this kind of errors when too old editor version is passed:

```@ckeditor_ckeditor5-react.js?v=4b120bc5:2535 Error: Window entry "CKEDITOR" not found.
    at @ckeditor_ckeditor5-react.js?v=4b120bc5:1011:15
    at tick (@ckeditor_ckeditor5-react.js?v=4b120bc5:811:30)```
