### PR TITLE
Adjust vanilla-js migrations path.

### DIFF
--- a/src/cdn/ck/createCKCdnBaseBundlePack.ts
+++ b/src/cdn/ck/createCKCdnBaseBundlePack.ts
@@ -84,7 +84,7 @@ export function createCKCdnBaseBundlePack(
 				case 'npm':
 					throw new Error(
 						'CKEditor 5 is already loaded from npm. Check the migration guide for more details: ' +
-						createCKDocsUrl( 'updating/migration-to-cdn/vanilla-js.html' )
+						createCKDocsUrl( 'updating/migrations/vanilla-js.html' )
 					);
 
 				case 'cdn':

--- a/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
+++ b/tests/cdn/ck/createCKCdnBaseBundlePack.test.ts
@@ -127,7 +127,7 @@ describe( 'createCKCdnBaseBundlePack', () => {
 
 		await expect( async () => loadCKEditor( '44.3.0' ) ).rejects.toThrowError(
 			'CKEditor 5 is already loaded from npm. Check the migration guide for more details: ' +
-			createCKDocsUrl( 'updating/migration-to-cdn/vanilla-js.html' )
+			createCKDocsUrl( 'updating/migrations/vanilla-js.html' )
 		);
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Updated migration link for Vanilla JS when the editor is installed via NPM but loaded via CDN.

---

### Additional information

Parent issue https://github.com/ckeditor/ckeditor5/issues/18510