### PR TITLE
Remove release instructions from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,6 @@ To build the package that is ready to publish, use the following command:
 pnpm run build
 ```
 
-## Releasing package
-
-CircleCI automates the release process and can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).
-
-Before you start, you need to prepare the changelog entries.
-
-1. Make sure the `#master` branch is up-to-date: `git fetch && git checkout master && git pull`.
-1. Prepare a release branch: `git checkout -b release-[YYYYMMDD]` where `YYYYMMDD` is the current day.
-1. Generate the changelog entries: `pnpm run release:prepare-changelog`.
-	* You can specify the release date by passing the `--date` option, e.g., `--date=2025-06-11`.
-	* By passing the `--dry-run` option, you can check what the script will do without actually modifying the files.
-	* Read all the entries, correct poor wording and other issues, wrap code names in backticks to format them, etc.
-	* Add the missing `the/a` articles, `()` to method names, "it's" -> "its", etc.
-	* A newly introduced feature should have just one changelog entry – something like "The initial implementation of the FOO feature." with a description of what it does.
-1. Commit all changes and prepare a new pull request targeting the `#master` branch.
-1. Ping the `@ckeditor/ckeditor-5-platform` team to review the pull request and trigger the release process.
-
 ## License
 
 Licensed under a dual-license model, this software is available under:


### PR DESCRIPTION
## Summary
- Removed the "Releasing package" section from the README — release instructions have been moved to [Notion](https://www.notion.so/Instructions-for-releasing-public-non-editor-CKEditor-5-repositories-32e66af06160498db71048c8f9e8106b) and should not be published on npm.

Closes https://github.com/ckeditor/ckeditor5-internal/issues/4495 (partially).